### PR TITLE
Use empty arrays to store metadata for group-based classes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: tiledbsc
 Type: Package
 Title: TileDB-based Single Cell Tools
 Description: A collection of experimental functions for working with single cell data using TileDB.
-Version: 0.0.0.9011
+Version: 0.0.0.9012
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/man/SCGroup.Rd
+++ b/man/SCGroup.Rd
@@ -39,6 +39,8 @@ which includes:
 \if{html}{
 \out{<details open ><summary>Inherited methods</summary>}
 \itemize{
+\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TiledbGroup" data-id="add_metadata">}\href{../../tiledbsc/html/TiledbGroup.html#method-add_metadata}{\code{tiledbsc::TiledbGroup$add_metadata()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TiledbGroup" data-id="get_metadata">}\href{../../tiledbsc/html/TiledbGroup.html#method-get_metadata}{\code{tiledbsc::TiledbGroup$get_metadata()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TiledbGroup" data-id="list_objects">}\href{../../tiledbsc/html/TiledbGroup.html#method-list_objects}{\code{tiledbsc::TiledbGroup$list_objects()}}\out{</span>}
 }
 \out{</details>}

--- a/man/TiledbGroup.Rd
+++ b/man/TiledbGroup.Rd
@@ -22,6 +22,8 @@ Base class for interacting with TileDB groups
 \itemize{
 \item \href{#method-new}{\code{TiledbGroup$new()}}
 \item \href{#method-list_objects}{\code{TiledbGroup$list_objects()}}
+\item \href{#method-get_metadata}{\code{TiledbGroup$get_metadata()}}
+\item \href{#method-add_metadata}{\code{TiledbGroup$add_metadata()}}
 \item \href{#method-clone}{\code{TiledbGroup$clone()}}
 }
 }
@@ -63,6 +65,51 @@ By default all object types are listed.}
 }
 \subsection{Returns}{
 A \code{data.frame} with columns \code{URI} and \code{TYPE}.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-get_metadata"></a>}}
+\if{latex}{\out{\hypertarget{method-get_metadata}{}}}
+\subsection{Method \code{get_metadata()}}{
+Retrieve metadata from the TileDB group.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TiledbGroup$get_metadata(key = NULL, prefix = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{key}}{The name of the metadata attribute to retrieve.}
+
+\item{\code{prefix}}{Filter metadata using an optional prefix. Ignored if \code{key}
+is not NULL.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+A list of metadata values.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-add_metadata"></a>}}
+\if{latex}{\out{\hypertarget{method-add_metadata}{}}}
+\subsection{Method \code{add_metadata()}}{
+Add list of metadata to the TileDB group.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TiledbGroup$add_metadata(metadata, prefix = "")}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{metadata}}{Named list of metadata to add.}
+
+\item{\code{prefix}}{Optional prefix to add to the metadata attribute names.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+NULL
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test_TiledbGroup.R
+++ b/tests/testthat/test_TiledbGroup.R
@@ -13,9 +13,8 @@ test_that("a new TileDB group can be created", {
   expect_match(tiledb::tiledb_object_type(grp_uri), "GROUP")
 })
 
-
 test_that("arrays within a group can be discovered", {
-  grp_uri <<- file.path(withr::local_tempdir(), "new-group")
+  grp_uri <- file.path(withr::local_tempdir(), "new-group")
   grp <- TiledbGroup$new(uri = grp_uri, verbose = FALSE)
 
   a1 <- create_empty_test_array(file.path(grp_uri, "a1"))
@@ -23,5 +22,15 @@ test_that("arrays within a group can be discovered", {
 
   objs <- grp$list_objects()
   expect_is(objs, "data.frame")
-  expect_equal(nrow(objs), 2)
+  # TODO: Change this back to 2 once TileDB supports group metadata
+  expect_equal(nrow(objs), 3)
+})
+
+test_that("metadata can be set and retrieved from a group", {
+  grp_uri <- file.path(withr::local_tempdir(), "metadata-group")
+  grp <- TiledbGroup$new(uri = grp_uri, verbose = TRUE)
+
+  md <- list(foo = "bar")
+  grp$add_metadata(md)
+  expect_equal(grp$get_metadata(key = "foo"), "bar")
 })


### PR DESCRIPTION
Provides the `TiledbGroup`-based classes (`SCGroup` and `SCDataset`)  with functionality for setting/retrieving metadata. 

As noted in the comments, the metadata is currently stored in empty arrays within the Tiledb groups until group-level metadata is supported in core.