### PR TITLE
Update minimum TileDB-R version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ LazyData: true
 Imports:
     tools,
     Matrix,
-    tiledb (>= 0.9.6),
+    tiledb (>= 0.11.0.10),
     Seurat,
     SeuratObject,
     png,


### PR DESCRIPTION
Updating required version of TileDB-R to ensure we can leverage recent updates from https://github.com/TileDB-Inc/TileDB-R/pull/371 around memory limits and looping over incompletes.

Note *TileDB-R* is specified as a [remote dependency](https://github.com/TileDB-Inc/tiledbsc/blob/660a1428212b8dd7c9361bb61e2413b62f3e6018/DESCRIPTION#L31-L32).