### PR TITLE
Fix conversion of Seurat Assay with empty counts slot

### DIFF
--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -126,6 +126,9 @@ SCGroup <- R6::R6Class(
       )
       assay_mats <- lapply(assay_mats, FUN = as, Class = "dgTMatrix")
 
+      # exclude empty matrices
+      assay_mats <- Filter(Negate(is_empty), assay_mats)
+
       # TODO: decide on a consistent naming convention for array dimensions
       index_cols <- c("var_id", "obs_id")
       self$X$from_dataframe(

--- a/tests/testthat/test_Seurat_SCGroup.R
+++ b/tests/testthat/test_Seurat_SCGroup.R
@@ -136,3 +136,17 @@ test_that("creation from a Seurat Assay without scale.data", {
     SeuratObject::GetAssayData(assay1, "scale.data")
   )
 })
+
+
+test_that("an assay with empty counts slot can be converted", {
+  assay <- SeuratObject::SetAssayData(
+    pbmc_small[["RNA"]],
+    slot = "counts",
+    new.data = new(Class = "matrix")
+  )
+
+  expect_true(is_empty(SeuratObject::GetAssayData(assay, "counts")))
+
+  scgroup <- SCGroup$new(withr::local_tempdir("assay-with-empty-counts"))
+  expect_silent(scgroup$from_seurat_assay(assay))
+})

--- a/tests/testthat/test_Seurat_SCGroup.R
+++ b/tests/testthat/test_Seurat_SCGroup.R
@@ -139,6 +139,7 @@ test_that("creation from a Seurat Assay without scale.data", {
 
 
 test_that("an assay with empty counts slot can be converted", {
+  uri <- withr::local_tempdir("assay-with-empty-counts")
   assay <- SeuratObject::SetAssayData(
     pbmc_small[["RNA"]],
     slot = "counts",
@@ -147,6 +148,6 @@ test_that("an assay with empty counts slot can be converted", {
 
   expect_true(is_empty(SeuratObject::GetAssayData(assay, "counts")))
 
-  scgroup <- SCGroup$new(withr::local_tempdir("assay-with-empty-counts"))
+  scgroup <- SCGroup$new(uri, verbose = FALSE)
   expect_silent(scgroup$from_seurat_assay(assay))
 })

--- a/tests/testthat/test_Seurat_SCGroup.R
+++ b/tests/testthat/test_Seurat_SCGroup.R
@@ -150,4 +150,20 @@ test_that("an assay with empty counts slot can be converted", {
 
   scgroup <- SCGroup$new(uri, verbose = FALSE)
   expect_silent(scgroup$from_seurat_assay(assay))
+  expect_match(tiledb::tiledb_object_type(scgroup$X$uri), "ARRAY")
+
+  assay2 <- scgroup$to_seurat_assay()
+
+  rlabs <- rownames(assay)
+  clabs <- colnames(assay)
+
+  expect_identical(
+    SeuratObject::GetAssayData(assay2, "data")[rlabs, clabs],
+    SeuratObject::GetAssayData(assay, "data")[rlabs, clabs]
+  )
+
+  expect_identical(
+    SeuratObject::GetAssayData(assay2, "counts"),
+    SeuratObject::GetAssayData(assay, "counts")
+  )
 })


### PR DESCRIPTION
- Add test for seurat assay with empty counts slot
- Filter empty assay matrices
- Fix test for ingesting countless assay
- Seurat assay conversion handles missing counts
