### PR TITLE
Include Dim Reductions when re-creating a Seurat object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: tiledbsc
 Type: Package
 Title: TileDB-based Single Cell Tools
 Description: A collection of experimental functions for working with single cell data using TileDB.
-Version: 0.0.0.9021
+Version: 0.0.0.9022
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/R/AnnotationPairwiseMatrix.R
+++ b/R/AnnotationPairwiseMatrix.R
@@ -61,8 +61,8 @@ AnnotationPairwiseMatrix <- R6::R6Class(
       )[[1]]
     },
 
-    #` @description Read annotation data from TileDB into Seurat Graph
-    #` @return A [`SeuratObject::Graph-class`]
+    #' @description Read annotation data from TileDB into Seurat Graph
+    #' @return A [`SeuratObject::Graph-class`]
     to_seurat_graph = function() {
       assay <- self$get_metadata(key = "assay_used")
       object <- SeuratObject::as.Graph(self$to_sparse_matrix())

--- a/R/AnnotationPairwiseMatrixGroup.R
+++ b/R/AnnotationPairwiseMatrixGroup.R
@@ -52,6 +52,7 @@ AnnotationPairwiseMatrixGroup <- R6::R6Class(
     #' - `graph_technique`: Name of the technique used to generate the graph.
     #' used.
     #'
+    #' @param object A [`SeuratObject::Graph`] object.
     #' @param technique Name of the technique used to generate the graph
     #' (typically, `nn` or `snn`).
     add_seurat_graph = function(object, technique) {

--- a/R/SCDataset.R
+++ b/R/SCDataset.R
@@ -88,7 +88,7 @@ SCDataset <- R6::R6Class(
         for (reduction in reductions) {
           reduction_object <- Seurat::Reductions(object, slot = reduction)
           assay <- SeuratObject::DefaultAssay(reduction_object)
-          self$scgroups[[assay]]$from_seurat_dimreduction(
+          self$scgroups[[assay]]$add_seurat_dimreduction(
             object = reduction_object,
             technique = reduction
           )

--- a/R/SCDataset.R
+++ b/R/SCDataset.R
@@ -136,6 +136,16 @@ SCDataset <- R6::R6Class(
         }
       }
 
+      # dimreductions
+      # Retrieve list of all techniques used in any scgroup's obsm/varm
+      # dimensionality reduction arrays. The association between assay and
+      # dimreduction is maintained by the DimReduc's `assay.used` slot.
+      dimreductions <- lapply(
+        self$scgroups,
+        function(x) x$get_seurat_dimreductions_list()
+      )
+      object@reductions <- Reduce(base::c, dimreductions)
+
       # graphs
       graph_arrays <- lapply(self$scgroups,
         function(x) x$get_annotation_pairwise_matrix_arrays(prefix = "graph_")

--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -330,6 +330,19 @@ SCGroup <- R6::R6Class(
       )
     },
 
+    #' @description Retrieve a list of all [`SeuratObject::DimReduc`] objects.
+    get_seurat_dimreductions_list = function() {
+      arrays <-self$get_annotation_matrix_arrays(prefix = "dimreduction_")
+      array_names <- names(unlist(arrays))
+      techniques <- unique(sub("(obs|var)m\\.dimreduction_", "", array_names))
+      sapply(
+        techniques,
+        function(x) self$to_seurat_dimreduction(x),
+        simplify = FALSE,
+        USE.NAMES = TRUE
+      )
+    },
+
     #' @description Convert to a [SeuratObject::Seurat] object.
     #' @param project [`SeuratObject::Project`] name for the `Seurat` object
     to_seurat_object = function(project = "SeuratProject") {

--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -238,7 +238,7 @@ SCGroup <- R6::R6Class(
     #' @param technique Name of the dimensional reduction technique. By default,
     #' the `key` slot is used to determine the technique.
 
-    from_seurat_dimreduction = function(object, technique = NULL) {
+    add_seurat_dimreduction = function(object, technique = NULL) {
       stopifnot(
         "Must provide a Seurat 'DimReduc' object" = inherits(object, "DimReduc")
       )
@@ -280,7 +280,7 @@ SCGroup <- R6::R6Class(
     #' @param technique Name of the dimensionality reduction technique. Used to
     #' identify which `obsm`/`varm` array will be retrieved. If `NULL`, we
     #' default to the first `obsm/dimreduction_` array.
-    to_seurat_dimreduction = function(technique = NULL) {
+    get_seurat_dimreduction = function(technique = NULL) {
 
       # Identify all obsm/varm dimreduction_ arrays
       prefix <- "dimreduction_"
@@ -337,7 +337,7 @@ SCGroup <- R6::R6Class(
       techniques <- unique(sub("(obs|var)m\\.dimreduction_", "", array_names))
       sapply(
         techniques,
-        function(x) self$to_seurat_dimreduction(x),
+        function(x) self$get_seurat_dimreduction(x),
         simplify = FALSE,
         USE.NAMES = TRUE
       )

--- a/R/TileDBGroup.R
+++ b/R/TileDBGroup.R
@@ -16,6 +16,8 @@ TileDBGroup <- R6::R6Class(
 
     #' @description Create a new TileDBGroup object.
     #' @param uri TileDB array URI
+    #' @param dimension_name Optional name of the dimension shared by all
+    #' arrays.
     #' @param verbose Print status messages
     initialize = function(uri, dimension_name = NULL, verbose = TRUE) {
       self$uri <- uri

--- a/man/AnnotationPairwiseMatrix.Rd
+++ b/man/AnnotationPairwiseMatrix.Rd
@@ -108,10 +108,14 @@ A \code{\link[Matrix:dgTMatrix-class]{Matrix::dgTMatrix}}.
 \if{html}{\out{<a id="method-to_seurat_graph"></a>}}
 \if{latex}{\out{\hypertarget{method-to_seurat_graph}{}}}
 \subsection{Method \code{to_seurat_graph()}}{
+Read annotation data from TileDB into Seurat Graph
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{AnnotationPairwiseMatrix$to_seurat_graph()}\if{html}{\out{</div>}}
 }
 
+\subsection{Returns}{
+A \code{\link[SeuratObject:Graph-class]{SeuratObject::Graph}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-clone"></a>}}

--- a/man/AnnotationPairwiseMatrixGroup.Rd
+++ b/man/AnnotationPairwiseMatrixGroup.Rd
@@ -67,6 +67,8 @@ Convert a \code{\link[SeuratObject:Graph-class]{SeuratObject::Graph}} object to
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
+\item{\code{object}}{A \code{\link[SeuratObject:Graph-class]{SeuratObject::Graph}} object.}
+
 \item{\code{technique}}{Name of the technique used to generate the graph
 (typically, \code{nn} or \code{snn}).}
 }

--- a/man/SCGroup.Rd
+++ b/man/SCGroup.Rd
@@ -45,8 +45,9 @@ of the \code{obs} and \code{var} arrays, respectively.}
 \item \href{#method-new}{\code{SCGroup$new()}}
 \item \href{#method-from_seurat_assay}{\code{SCGroup$from_seurat_assay()}}
 \item \href{#method-to_seurat_assay}{\code{SCGroup$to_seurat_assay()}}
-\item \href{#method-from_seurat_dimreduction}{\code{SCGroup$from_seurat_dimreduction()}}
-\item \href{#method-to_seurat_dimreduction}{\code{SCGroup$to_seurat_dimreduction()}}
+\item \href{#method-add_seurat_dimreduction}{\code{SCGroup$add_seurat_dimreduction()}}
+\item \href{#method-get_seurat_dimreduction}{\code{SCGroup$get_seurat_dimreduction()}}
+\item \href{#method-get_seurat_dimreductions_list}{\code{SCGroup$get_seurat_dimreductions_list()}}
 \item \href{#method-to_seurat_object}{\code{SCGroup$to_seurat_object()}}
 \item \href{#method-get_annotation_matrix_arrays}{\code{SCGroup$get_annotation_matrix_arrays()}}
 \item \href{#method-get_annotation_pairwise_matrix_arrays}{\code{SCGroup$get_annotation_pairwise_matrix_arrays()}}
@@ -138,12 +139,12 @@ values}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-from_seurat_dimreduction"></a>}}
-\if{latex}{\out{\hypertarget{method-from_seurat_dimreduction}{}}}
-\subsection{Method \code{from_seurat_dimreduction()}}{
+\if{html}{\out{<a id="method-add_seurat_dimreduction"></a>}}
+\if{latex}{\out{\hypertarget{method-add_seurat_dimreduction}{}}}
+\subsection{Method \code{add_seurat_dimreduction()}}{
 Convert a \code{\link[SeuratObject:DimReduc-class]{SeuratObject::DimReduc}} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SCGroup$from_seurat_dimreduction(object, technique = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SCGroup$add_seurat_dimreduction(object, technique = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -179,12 +180,12 @@ results column names (required by Seurat)
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_seurat_dimreduction"></a>}}
-\if{latex}{\out{\hypertarget{method-to_seurat_dimreduction}{}}}
-\subsection{Method \code{to_seurat_dimreduction()}}{
+\if{html}{\out{<a id="method-get_seurat_dimreduction"></a>}}
+\if{latex}{\out{\hypertarget{method-get_seurat_dimreduction}{}}}
+\subsection{Method \code{get_seurat_dimreduction()}}{
 Convert to a \code{\link[SeuratObject:DimReduc-class]{SeuratObject::DimReduc}} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SCGroup$to_seurat_dimreduction(technique = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SCGroup$get_seurat_dimreduction(technique = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -196,6 +197,16 @@ default to the first \code{obsm/dimreduction_} array.}
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-get_seurat_dimreductions_list"></a>}}
+\if{latex}{\out{\hypertarget{method-get_seurat_dimreductions_list}{}}}
+\subsection{Method \code{get_seurat_dimreductions_list()}}{
+Retrieve a list of all \code{\link[SeuratObject:DimReduc-class]{SeuratObject::DimReduc}} objects.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SCGroup$get_seurat_dimreductions_list()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-to_seurat_object"></a>}}

--- a/man/TileDBGroup.Rd
+++ b/man/TileDBGroup.Rd
@@ -51,6 +51,9 @@ Create a new TileDBGroup object.
 \describe{
 \item{\code{uri}}{TileDB array URI}
 
+\item{\code{dimension_name}}{Optional name of the dimension shared by all
+arrays.}
+
 \item{\code{verbose}}{Print status messages}
 }
 \if{html}{\out{</div>}}

--- a/tests/testthat/test_Seurat_SCDataset.R
+++ b/tests/testthat/test_Seurat_SCDataset.R
@@ -43,7 +43,23 @@ test_that("SCDataset can be created from a Seurat object", {
   expect_length(scgroup$varm$arrays, 1)
   expect_length(scgroup$obsp$arrays, 1)
 
+  # validate restored aux data
   pbmc_small2 <- scdataset2$to_seurat()
+
+  reductions <- SeuratObject::Reductions(pbmc_small)
+  for (r in reductions) {
+    reduc1 <- SeuratObject::Reductions(pbmc_small, r)
+    reduc2 <- SeuratObject::Reductions(pbmc_small2, r)
+
+    load1 <- SeuratObject::Loadings(reduc1)
+    load2 <- SeuratObject::Loadings(reduc2)
+    expect_identical(load2[rownames(load1), ], load1)
+
+    embed1 <- SeuratObject::Embeddings(reduc1)
+    embed2 <- SeuratObject::Embeddings(reduc2)
+    expect_identical(embed2[rownames(embed1), ], embed1)
+  }
+
   expect_identical(
     SeuratObject::Graphs(pbmc_small2),
     SeuratObject::Graphs(pbmc_small)

--- a/tests/testthat/test_Seurat_SCGroup.R
+++ b/tests/testthat/test_Seurat_SCGroup.R
@@ -75,7 +75,7 @@ test_that("dimensional reduction data can be stored and retrieved", {
   expect_length(scgroup$varm$arrays, 0L)
 
   pca1 <- SeuratObject::Reductions(pbmc_small, slot = "pca")
-  scgroup$from_seurat_dimreduction(pca1, technique = "pca")
+  scgroup$add_seurat_dimreduction(pca1, technique = "pca")
 
   # obsm/varm are discovered
   scgroup <- SCGroup$new(uri = tdb_uri)
@@ -93,7 +93,7 @@ test_that("dimensional reduction data can be stored and retrieved", {
   )
 
   # validate recreated dimreduction data
-  pca2 <- scgroup$to_seurat_dimreduction()
+  pca2 <- scgroup$get_seurat_dimreduction()
 
   var_ids <- rownames(SeuratObject::Loadings(pca1))
   expect_identical(
@@ -109,8 +109,8 @@ test_that("dimensional reduction data can be stored and retrieved", {
 
   # tsne results only include cell-aligned Embeddings
   tsne1 <- SeuratObject::Reductions(pbmc_small, slot = "tsne")
-  scgroup$from_seurat_dimreduction(tsne1, technique = "tsne")
-  tsne2 <- scgroup$to_seurat_dimreduction(technique = "tsne")
+  scgroup$add_seurat_dimreduction(tsne1, technique = "tsne")
+  tsne2 <- scgroup$get_seurat_dimreduction(technique = "tsne")
 
   expect_identical(
     SeuratObject::Embeddings(tsne2)[obs_ids, ],

--- a/tests/testthat/test_Seurat_SCGroup.R
+++ b/tests/testthat/test_Seurat_SCGroup.R
@@ -107,7 +107,7 @@ test_that("dimensional reduction data can be stored and retrieved", {
     SeuratObject::Embeddings(pca1)[obs_ids, ]
   )
 
-  # tnse results only include cell-aligned Embeddings
+  # tsne results only include cell-aligned Embeddings
   tsne1 <- SeuratObject::Reductions(pbmc_small, slot = "tsne")
   scgroup$from_seurat_dimreduction(tsne1, technique = "tsne")
   tsne2 <- scgroup$to_seurat_dimreduction(technique = "tsne")


### PR DESCRIPTION
Seurat `DimReduc` objections are now re-constructed from the appropriate `obsm`/`varm` arrays when converting an `sc_dataset` back to a `Seurat` object.

Additionally, `SCDataset` methods for handling Seurat `DimReduc` objects have been renamed: 

- `from_seurat_dimreduction()` is now `add_seurat_dimreduction()`
- `to_seurat_dimreduction()` is now `get_seurat_dimreduction()`

This aligns with the convention elsewhere in the package (e.g., `add_seurat_graph()`/`get_seurat_graph()`) and
Is intended is to make a meaningful distinction between conversion and modification methods.  
