### PR TITLE
Improve support for remote URIs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: tiledbsc
 Type: Package
 Title: TileDB-based Single Cell Tools
 Description: A collection of experimental functions for working with single cell data using TileDB.
-Version: 0.0.0.9028
+Version: 0.0.0.9029
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/R/AnnotationMatrixGroup.R
+++ b/R/AnnotationMatrixGroup.R
@@ -26,7 +26,7 @@ AnnotationMatrixGroup <- R6::R6Class(
       # TODO: Verify that the matrix is aligned to the group's dimension
 
       # create the new array
-      array_uri <- file.path(self$uri, name)
+      array_uri <- file_path(self$uri, name)
       array <- AnnotationMatrix$new(
         uri = array_uri,
         verbose = self$verbose

--- a/R/AnnotationPairwiseMatrixGroup.R
+++ b/R/AnnotationPairwiseMatrixGroup.R
@@ -26,7 +26,7 @@ AnnotationPairwiseMatrixGroup <- R6::R6Class(
 
       # TODO: Verify that the matrix is aligned to the group's dimension
       # create the new array
-      array_uri <- file.path(self$uri, name)
+      array_uri <- file_path(self$uri, name)
       array <- AnnotationPairwiseMatrix$new(
         uri = array_uri,
         verbose = self$verbose

--- a/R/AssayMatrixGroup.R
+++ b/R/AssayMatrixGroup.R
@@ -27,7 +27,7 @@ AssayMatrixGroup <- R6::R6Class(
       }
 
       # create the new array
-      array_uri <- file.path(self$uri, name)
+      array_uri <- file_path(self$uri, name)
       array <- AssayMatrix$new(
         uri = array_uri,
         verbose = self$verbose

--- a/R/SCDataset.R
+++ b/R/SCDataset.R
@@ -57,7 +57,7 @@ SCDataset <- R6::R6Class(
       }
 
       self$commandsArray <- CommandsArray$new(
-        uri = file.path(self$uri, "commands"),
+        uri = file_path(self$uri, "commands"),
         verbose = self$verbose
       )
 
@@ -86,7 +86,7 @@ SCDataset <- R6::R6Class(
       assays <- SeuratObject::Assays(object)
       for (assay in assays) {
         assay_object <- Seurat::GetAssay(object, assay)
-        assay_uri <- file.path(self$uri, paste0("scgroup_", assay))
+        assay_uri <- file_path(self$uri, paste0("scgroup_", assay))
         scgroup <- SCGroup$new(assay_uri, verbose = self$verbose)
         scgroup$from_seurat_assay(assay_object, obs = object[[]])
         self$scgroups[[assay]] <- scgroup

--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -52,41 +52,41 @@ SCGroup <- R6::R6Class(
       }
 
       self$obs <- AnnotationDataframe$new(
-        uri = paste0(self$uri, "/obs"),
+        uri = file_path(self$uri, "obs"),
         verbose = self$verbose
       )
 
       self$var <- AnnotationDataframe$new(
-        uri = paste0(self$uri, "/var"),
+        uri = file_path(self$uri, "var"),
         verbose = self$verbose
       )
 
       self$X <- AssayMatrixGroup$new(
-        uri = paste0(self$uri, "/X"),
+        uri = file_path(self$uri, "X"),
         dimension_name = c("obs_id", "var_id"),
         verbose = self$verbose
       )
 
       self$obsm <- AnnotationMatrixGroup$new(
-        uri = file.path(self$uri, "obsm"),
+        uri = file_path(self$uri, "obsm"),
         dimension_name = "obs_id",
         verbose = self$verbose
       )
 
       self$varm <- AnnotationMatrixGroup$new(
-        uri = file.path(self$uri, "varm"),
+        uri = file_path(self$uri, "varm"),
         dimension_name = "var_id",
         verbose = self$verbose
       )
 
       self$obsp <- AnnotationPairwiseMatrixGroup$new(
-        uri = file.path(self$uri, "obsp"),
+        uri = file_path(self$uri, "obsp"),
         dimension_name = "obs_id",
         verbose = self$verbose
       )
 
       self$varp <- AnnotationPairwiseMatrixGroup$new(
-        uri = file.path(self$uri, "varp"),
+        uri = file_path(self$uri, "varp"),
         dimension_name = "var_id",
         verbose = self$verbose
       )

--- a/R/TileDBGroup.R
+++ b/R/TileDBGroup.R
@@ -26,7 +26,7 @@ TileDBGroup <- R6::R6Class(
 
       # Until TileDB supports group metadata, we need to create an array
       # to store the metadata.
-      private$metadata_uri <- file.path(self$uri, "__tiledb_group_metadata")
+      private$metadata_uri <- file_path(self$uri, "__tiledb_group_metadata")
 
       if (!private$group_exists()) {
         private$create_group()

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,3 +66,16 @@ check_package <- function(package) {
   }
   stop(paste0("Package '", package, "' must be installed"))
 }
+
+# Drop-in replacement for file.paths() that ignores the platform separator when
+# constructing remote S3 or TileDB URIs
+file_path <- function(..., fsep = .Platform$file.sep) {
+  paths <- list(...)
+  if (
+    string_starts_with(paths[[1]], "s3://") ||
+    string_starts_with(paths[[1]], "tiledb://")
+  ) {
+    fsep <- "/"
+  }
+  file.path(..., fsep = fsep)
+}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,9 +1,0 @@
-test_that("renaming works", {
-  vec1 <- c(a = 1, b = 2, c = 3)
-  vec2 <- rename(vec1, c(A = "a", C = "c"))
-  expect_identical(names(vec2), c("A", "b", "C"))
-  expect_error(
-    rename(vec1, c(A = "notpresent")),
-    "All 'names' must be in 'x'"
-  )
-})

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -28,3 +28,22 @@ test_that("vector renaming works", {
     "All 'names' must be in 'x'"
   )
 })
+
+test_that("file path construction handles remote URLs", {
+  expect_identical(
+    file_path("foo"),
+    file.path("foo")
+  )
+  expect_identical(
+    file_path("foo", "bar"),
+    file.path("foo", "bar")
+  )
+  expect_identical(
+    file_path("s3://my", "bucket", fsep = "\\"),
+    "s3://my/bucket"
+  )
+  expect_identical(
+    file_path("tiledb://my", "array", fsep = "\\"),
+    "tiledb://my/array"
+  )
+})

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -18,3 +18,13 @@ test_that("matrices with empty dimensions are detected", {
     has_dimnames(Matrix::Matrix(1, dimnames = list("A", "B")))
   )
 })
+
+test_that("vector renaming works", {
+  vec1 <- c(a = 1, b = 2, c = 3)
+  vec2 <- rename(vec1, c(A = "a", C = "c"))
+  expect_identical(names(vec2), c("A", "b", "C"))
+  expect_error(
+    rename(vec1, c(A = "notpresent")),
+    "All 'names' must be in 'x'"
+  )
+})


### PR DESCRIPTION
Using `file.path()` could lead to problems for Windows users when working with `s3://` or `tiledb://` URIs. This adds a new drop-in replacement that ignores the platform's file separator when dealing with remote URIs.