### PR TITLE
Drop Seurat as a dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,6 @@ Imports:
     methods,
     Matrix,
     tiledb (>= 0.11.0.16),
-    Seurat,
     SeuratObject,
     jsonlite,
     glue,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: tiledbsc
 Type: Package
 Title: TileDB-based Single Cell Tools
 Description: A collection of experimental functions for working with single cell data using TileDB.
-Version: 0.0.0.9036
+Version: 0.0.0.9037
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/R/SCDataset.R
+++ b/R/SCDataset.R
@@ -83,7 +83,7 @@ SCDataset <- R6::R6Class(
 
       assays <- SeuratObject::Assays(object)
       for (assay in assays) {
-        assay_object <- Seurat::GetAssay(object, assay)
+        assay_object <- object[[assay]]
         assay_uri <- file_path(self$uri, paste0("scgroup_", assay))
         scgroup <- SCGroup$new(assay_uri, verbose = self$verbose)
         scgroup$from_seurat_assay(assay_object, obs = object[[]])

--- a/R/SCDataset.R
+++ b/R/SCDataset.R
@@ -93,7 +93,7 @@ SCDataset <- R6::R6Class(
       reductions <- SeuratObject::Reductions(object)
       if (!is_empty(reductions)) {
         for (reduction in reductions) {
-          reduction_object <- Seurat::Reductions(object, slot = reduction)
+          reduction_object <- SeuratObject::Reductions(object, slot = reduction)
           assay <- SeuratObject::DefaultAssay(reduction_object)
           self$scgroups[[assay]]$add_seurat_dimreduction(
             object = reduction_object,
@@ -146,7 +146,7 @@ SCDataset <- R6::R6Class(
       # just take the first scgroup's obs metadata
       obs_df <- self$scgroups[[1]]$obs$to_dataframe()
 
-      object <- Seurat::CreateSeuratObject(
+      object <- SeuratObject::CreateSeuratObject(
         counts = assays[[1]],
         project = project,
         meta.data = obs_df

--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -406,7 +406,7 @@ SCGroup <- R6::R6Class(
       assay_obj <- self$to_seurat_assay()
       obs_df <- self$obs$to_dataframe()[colnames(assay_obj), , drop = FALSE]
 
-      Seurat::CreateSeuratObject(
+      SeuratObject::CreateSeuratObject(
         counts = assay_obj,
         project = project,
         meta.data = obs_df

--- a/tests/testthat/test_AnnotationPairwiseMatrix_Seurat_Graph.R
+++ b/tests/testthat/test_AnnotationPairwiseMatrix_Seurat_Graph.R
@@ -2,10 +2,7 @@ test_that("graph data can be stored and retrieved", {
   uri <- withr::local_tempdir("test-scgroup-graph")
   scgroup <- SCGroup$new(uri = uri)
 
-  scgroup$from_seurat_assay(
-    Seurat::GetAssay(pbmc_small, "RNA"),
-    obs = pbmc_small[[]]
-  )
+  scgroup$from_seurat_assay(pbmc_small[["RNA"]], obs = pbmc_small[[]])
 
   # obsp/varp are empty
   expect_length(scgroup$obsp$arrays, 0L)

--- a/tests/testthat/test_AssayMatrix.R
+++ b/tests/testthat/test_AssayMatrix.R
@@ -1,6 +1,6 @@
 test_that("AssayMatrix object can be created from a dgCMatrix", {
   uri <- withr::local_tempdir("assay-matrix")
-  mat <- Seurat::GetAssayData(pbmc_small[["RNA"]], "counts")
+  mat <- SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
 
   assaymat <- AssayMatrix$new(uri = uri, verbose = FALSE)
   expect_true(inherits(assaymat, "AssayMatrix"))
@@ -23,13 +23,13 @@ test_that("AssayMatrix object can be created from a dgCMatrix", {
 
 test_that("matrices can be added to an AssayMatrixGroup", {
   uri <- withr::local_tempdir("assay-matrix-group")
-  mat <- Seurat::GetAssayData(pbmc_small[["RNA"]], "counts")
+  mat <- SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
 
   assaymats <- AssayMatrixGroup$new(uri = uri, dimension_name = c("obs_id", "var_id"))
   expect_length(assaymats$arrays, 0)
 
   assaymats$add_assay_matrix(
-    data = Seurat::GetAssayData(pbmc_small[["RNA"]], "counts"),
+    data = SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts"),
     name = "counts"
   )
   expect_true(inherits(assaymats$arrays[["counts"]], "AssayMatrix"))

--- a/tests/testthat/test_SCDataset_Seurat.R
+++ b/tests/testthat/test_SCDataset_Seurat.R
@@ -66,8 +66,8 @@ test_that("SCDataset can be created from a Seurat object", {
   )
 
   # check for commands
-  command_names <- Seurat::Command(object=pbmc_small)
-  command_names2 <- Seurat::Command(object=pbmc_small2)
+  command_names <- SeuratObject::Command(object=pbmc_small)
+  command_names2 <- SeuratObject::Command(object=pbmc_small2)
   expect_identical(command_names, command_names2)
 
   # calling from_seurat again will update the existing data
@@ -84,7 +84,7 @@ test_that("a dataset containing an assay with empty cells is fully retrieved", {
   cell_ids <- SeuratObject::Cells(pbmc_small)
 
   # remove all counts for a subset of cells
-  counts2 <- Seurat::GetAssayData(pbmc_small[["RNA"]], "counts")
+  counts2 <- SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
   counts2[, 1:10] <- 0
   pbmc_small[["RNA2"]] <- SeuratObject::CreateAssayObject(counts = counts2)
 

--- a/tests/testthat/test_SCGroup_Seurat.R
+++ b/tests/testthat/test_SCGroup_Seurat.R
@@ -180,8 +180,11 @@ test_that("creation from a Seurat Assay without scale.data", {
 test_that("an assay with scale.data containing all features", {
   uri <- withr::local_tempdir()
 
-  SeuratObject::VariableFeatures(assay1) <- character()
-  assay1 <- Seurat::ScaleData(assay1)
+  # create a seurat object containing on
+  object1 <- pbmc_small[SeuratObject::VariableFeatures(pbmc_small),]
+  SeuratObject::VariableFeatures(object1) <- character()
+  assay1 <- object1[["RNA"]]
+
   expect_identical(
     dim(SeuratObject::GetAssayData(assay1, "counts")),
     dim(SeuratObject::GetAssayData(assay1, "scale.data"))

--- a/tests/testthat/test_SCGroup_Seurat.R
+++ b/tests/testthat/test_SCGroup_Seurat.R
@@ -1,6 +1,6 @@
 setup({
   tdb_uri <<- file.path(tempdir(), "test-scgroup")
-  assay1 <<- Seurat::GetAssay(pbmc_small, "RNA")
+  assay1 <<- pbmc_small[["RNA"]]
 })
 
 teardown({

--- a/tests/testthat/test_SCGroup_Seurat.R
+++ b/tests/testthat/test_SCGroup_Seurat.R
@@ -85,7 +85,7 @@ test_that("obs and var are created when even no annotations are present", {
   uri <- withr::local_tempdir("assay-with-no-annotations")
 
   assay <- SeuratObject::CreateAssayObject(
-    counts = Seurat::GetAssayData(pbmc_small[["RNA"]], "counts")
+    counts = SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
   )
   expect_true(is_empty(assay[[]]))
   SeuratObject::Key(assay) <- "RNA"
@@ -234,7 +234,7 @@ test_that("an assay with empty feature metdata can be converted", {
   uri <- withr::local_tempdir("assay-without-feature-metadata")
 
   assay <- SeuratObject::CreateAssayObject(
-    counts = Seurat::GetAssayData(pbmc_small[["RNA"]], "counts")
+    counts = SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
   )
   SeuratObject::Key(assay) <- "RNA"
   expect_true(is_empty(assay[[]]))

--- a/tests/testthat/test_SCGroup_SummarizedExperiment.R
+++ b/tests/testthat/test_SCGroup_SummarizedExperiment.R
@@ -3,7 +3,7 @@
 test_that("a SummarizedExperiment can be created from an existing SCGroup", {
   uri <- file.path(withr::local_tempdir(), "scgroup")
 
-  assay <- Seurat::GetAssay(pbmc_small, "RNA")
+  assay <- pbmc_small[["RNA"]]
   scgroup <- SCGroup$new(uri = uri)
   scgroup$from_seurat_assay(assay, obs = pbmc_small[[]])
 

--- a/vignettes/seurat-to-scgroup.Rmd
+++ b/vignettes/seurat-to-scgroup.Rmd
@@ -22,7 +22,7 @@ options(max.print = 500)
 library(tiledbsc)
 library(fs)
 library(tiledb)
-library(Seurat)
+library(SeuratObject)
 
 data_dir <- file.path(tempdir(), "pbmc_small")
 dir.create(data_dir, showWarnings = FALSE)
@@ -30,7 +30,7 @@ dir.create(data_dir, showWarnings = FALSE)
 
 ## Overview
 
-This vignette will cover the creation of an **sc_dataset** from a `Seurat` object. 
+This vignette will cover the creation of an **sc_dataset** from a `Seurat` object.
 
 ## Load data
 
@@ -88,13 +88,13 @@ scgroup <- SCGroup$new(uri = file.path(tempdir(), "sc_group"))
 fs::dir_tree(scgroup$uri)
 ```
 
-Then we'll pass `RNA` assay from `pbmc_small` to the `from_seurat_assay()` method of the `SCGroup` class. 
+Then we'll pass `RNA` assay from `pbmc_small` to the `from_seurat_assay()` method of the `SCGroup` class.
 
 *Note: Because cell-level metadata is stored in the parent `Seurat` object, we need to provide this data separately.*
 
 ```{r}
 scgroup$from_seurat_assay(
-  object = GetAssay(pbmc_small, assay = "RNA"),
+  object = pbmc_small[["RNA"]],
   obs = pbmc_small[[]]
 )
 ```


### PR DESCRIPTION
Seurat is nicely modularized to cleanly separate the implementation of it classes from the rest of the package. For our purposes, only methods from SeuratObject are needed, which has many fewer dependencies than Seurat itself. 

This PR drops Seurat as a dependency by:
- ensuring methods originating from SeuratObject are imported from there rather than via Seurat
- and drops the use of any other methods from Seurat

