### PR TITLE
Add pkgdown::build_site CI

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,36 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # This is GitHub Actions magic -- there are no secrets we as package owners need to set up or manage
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: pkgdown
+          needs: website
+
+      - name: Deploy package
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'


### PR DESCRIPTION
Already in use at https://github.com/TileDB-Inc/TileDB-Cloud-R

After this, in Settings -> Pages, someone with admin permissions for this repo needs to set GitHub Pages to publish from branch `gh-pages` from directory `root`.

Also just now I did

```
git checkout -b gh-pages
git push --set-upstream origin gh-pages
```

which created the `gh-pages` branch server-side.

Then docs at https://tiledb-inc.github.io/tiledbsc/.