### PR TITLE
Update tiledb-r to 0.11.1.1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,7 +39,7 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Install dependencies
         env:
           R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+          _R_CHECK_FORCE_SUGGESTS_: false
         run: Rscript -e "install.packages(c('remotes', 'rcmdcheck'))" -e "remotes::install_deps(dependencies = TRUE)"
 
       - uses: r-lib/actions/check-r-package@v1

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,6 +27,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      _R_CHECK_FORCE_SUGGESTS_: false
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +43,6 @@ jobs:
       - name: Install dependencies
         env:
           R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-          _R_CHECK_FORCE_SUGGESTS_: false
         run: Rscript -e "install.packages(c('remotes', 'rcmdcheck'))" -e "remotes::install_deps(dependencies = TRUE)"
 
       - uses: r-lib/actions/check-r-package@v1

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,8 +39,9 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: rcmdcheck
+      - name: Install dependencies
+        env:
+          R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+        run: Rscript -e "install.packages(c('remotes', 'rcmdcheck'))" -e "remotes::install_deps(dependencies = TRUE)"
 
       - uses: r-lib/actions/check-r-package@v1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.0.9000
+Version: 0.1.0.9001
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,11 +34,13 @@ Imports:
     R6,
     methods,
     Matrix,
-    tiledb (>= 0.11.1),
+    tiledb (>= 0.11.1.1),
     SeuratObject,
     jsonlite,
     glue,
     utils
+Remotes:
+    tiledb-inc/tiledb-r@f3b7850
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
 Suggests:

--- a/tests/testthat/test_SCGroup_SummarizedExperiment.R
+++ b/tests/testthat/test_SCGroup_SummarizedExperiment.R
@@ -1,6 +1,7 @@
 # TODO: Add tests for creating an SCGroup from a SummarizedExperiment
 
 test_that("a SummarizedExperiment can be created from an existing SCGroup", {
+  skip_if_not_installed("SummarizedExperiment")
   uri <- file.path(withr::local_tempdir(), "scgroup")
 
   assay <- pbmc_small[["RNA"]]
@@ -46,6 +47,7 @@ test_that("a SummarizedExperiment can be created from an existing SCGroup", {
 
 
 test_that("a SingleCellExperiment can be created from an existing SCGroup", {
+  skip_if_not_installed("SummarizedExperiment")
   uri <- file.path(withr::local_tempdir(), "singlecellexperiment")
 
   # start with scdataset so the scgroup includes annot matrices


### PR DESCRIPTION
This bumps the minimum required version of tiledb-r to 0.11.1.1, which includes a [fix](https://github.com/TileDB-Inc/TileDB-R/pull/385) for pkg-config detection that could cause installation to fail.

This version is only available on GitHub so the `Remotes` field has been added back to `DESCRIPTION`. I've also pinned the remotes version to a specific of commit that includes Tiledb-Inc/Tiledb-R#385 but does not yet include support for the new Groups API (Tiledb-Inc/Tiledb-R#388), which requires TileDB v2.8 (currently a RC).

**CI changes**

To accommodate installation of tiledb-r from github I dropped the pak-based *setup-r-dependencies* action in favor of a custom step using the remotes package. One side effect of this change is the Bioc packages in *Suggests* are not installed, so `_R_CHECK_FORCE_SUGGESTS_` is now to set to false to avoid check errors  
and 2 bioc-related tests are skipped if the packages aren't available. 
