### PR TITLE
Fix pkgdown rendering

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -5,8 +5,6 @@ on:
     branches: [main]
   release:
     types: [published]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 name: pkgdown

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,10 +24,10 @@ jobs:
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
-        with:
-          extra-packages: pkgdown
-          needs: website
+      - name: Install dependencies
+        env:
+          R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+        run: Rscript -e "install.packages(c('remotes', 'pkgdown'))" -e "remotes::install_deps(dependencies = TRUE)"
 
       - name: Deploy package
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         env:
           R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-        run: Rscript -e "install.packages(c('remotes', 'pkgdown'))" -e "remotes::install_deps(dependencies = TRUE)"
+        run: Rscript -e "install.packages(c('remotes', 'pkgdown'))" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_local()"
 
       - name: Deploy package
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   release:
     types: [published]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 name: pkgdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.0.9001
+Version: 0.1.0.9002
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",


### PR DESCRIPTION
The pkgdown gha job needs to follow the same strategy used in the R-CMD-check workflow for installing deps to support installing tiledb-r via remotes.
