### PR TITLE
Don't force relative paths for group members

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.0.9002
+Version: 0.1.0.9003
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/R/AnnotationMatrixGroup.R
+++ b/R/AnnotationMatrixGroup.R
@@ -34,7 +34,7 @@ AnnotationMatrixGroup <- R6::R6Class(
 
       array$from_matrix(data, self$dimension_name)
       if (!is.null(metadata)) array$add_metadata(metadata)
-      self$add_member(array, name, relative = TRUE)
+      self$add_member(array, name)
     }
   ),
 

--- a/R/AnnotationPairwiseMatrixGroup.R
+++ b/R/AnnotationPairwiseMatrixGroup.R
@@ -35,7 +35,7 @@ AnnotationPairwiseMatrixGroup <- R6::R6Class(
       index_cols <- paste(self$dimension_name, c("i", "j"), sep = "_")
       array$from_matrix(data, index_cols)
       if (!is.null(metadata)) array$add_metadata(metadata)
-      self$add_member(array, name, relative = TRUE)
+      self$add_member(array, name)
     },
 
     #' @description Convert a [`SeuratObject::Graph`] object to

--- a/R/AssayMatrixGroup.R
+++ b/R/AssayMatrixGroup.R
@@ -39,7 +39,7 @@ AssayMatrixGroup <- R6::R6Class(
         value_col = value_col
       )
       if (!is.null(metadata)) array$add_metadata(metadata)
-      self$add_member(array, name, relative = TRUE)
+      self$add_member(array, name)
     }
   ),
 

--- a/R/SCDataset.R
+++ b/R/SCDataset.R
@@ -72,7 +72,7 @@ SCDataset <- R6::R6Class(
         assay_uri <- file_path(self$uri, paste0("scgroup_", assay))
         scgroup <- SCGroup$new(assay_uri, verbose = self$verbose)
         scgroup$from_seurat_assay(assay_object, obs = object[[]])
-        self$add_member(scgroup, name = assay, relative = TRUE)
+        self$add_member(scgroup, name = assay)
       }
 
       reductions <- SeuratObject::Reductions(object)

--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -73,7 +73,7 @@ SCGroup <- R6::R6Class(
           uri = file_path(self$uri, "X"),
           verbose = self$verbose
         )
-        self$add_member(self$X, name = "X", relative = TRUE)
+        self$add_member(self$X, name = "X")
       }
       # TODO: Store dimension_name in the group metadata when support for
       # string vectors are supported
@@ -86,7 +86,7 @@ SCGroup <- R6::R6Class(
           uri = file_path(self$uri, "obsm"),
           verbose = self$verbose
         )
-        self$add_member(self$obsm, name = "obsm", relative = TRUE)
+        self$add_member(self$obsm, name = "obsm")
       }
       self$obsm$dimension_name <- "obs_id"
 
@@ -97,7 +97,7 @@ SCGroup <- R6::R6Class(
           uri = file_path(self$uri, "varm"),
           verbose = self$verbose
         )
-        self$add_member(self$varm, name = "varm", relative = TRUE)
+        self$add_member(self$varm, name = "varm")
       }
       self$varm$dimension_name <- "var_id"
 
@@ -108,7 +108,7 @@ SCGroup <- R6::R6Class(
           uri = file_path(self$uri, "obsp"),
           verbose = self$verbose
         )
-        self$add_member(self$obsp, name = "obsp", relative = TRUE)
+        self$add_member(self$obsp, name = "obsp")
       }
       self$obsp$dimension_name <- "obs_id"
 
@@ -119,7 +119,7 @@ SCGroup <- R6::R6Class(
           uri = file_path(self$uri, "varp"),
           verbose = self$verbose
         )
-        self$add_member(self$varp, name = "varp", relative = TRUE)
+        self$add_member(self$varp, name = "varp")
       }
       self$varp$dimension_name <- "var_id"
 
@@ -130,7 +130,7 @@ SCGroup <- R6::R6Class(
           uri = file_path(self$uri, "misc"),
           verbose = self$verbose
         )
-        self$add_member(self$misc, name = "misc", relative = TRUE)
+        self$add_member(self$misc, name = "misc")
       }
     },
 
@@ -165,7 +165,7 @@ SCGroup <- R6::R6Class(
       }
       self$obs$from_dataframe(obs, index_col = "obs_id")
       if (is.null(self$get_member("obs"))) {
-        self$add_member(self$obs, name = "obs", relative = TRUE)
+        self$add_member(self$obs, name = "obs")
       }
 
       if (!is_empty(SeuratObject::VariableFeatures(object))) {
@@ -177,7 +177,7 @@ SCGroup <- R6::R6Class(
       }
       self$var$from_dataframe(object[[]], index_col = "var_id")
       if (is.null(self$get_member("var"))) {
-        self$add_member(self$var, name = "var", relative = TRUE)
+        self$add_member(self$var, name = "var")
       }
 
       assay_slots <- c("counts", "data")

--- a/R/TileDBGroup.R
+++ b/R/TileDBGroup.R
@@ -101,12 +101,19 @@ TileDBGroup <- R6::R6Class(
     #' @param relative A logical value indicating whether the new member's URI
     #' is relative to the group's URI.
     #' @importFrom fs path_rel
-    add_member = function(object, name = NULL, relative = TRUE) {
+    add_member = function(object, name = NULL, relative = NULL) {
       stopifnot(
         "Only 'TileDBArray' or 'TileDBGroup' objects can be added" =
           inherits(object, "TileDBGroup") || inherits(object, "TileDBArray"),
         is.null(name) || is_scalar_character(name)
       )
+
+      if (is.null(relative)) {
+        relative = TRUE
+        if (startsWith(object$uri, "tiledb://")) {
+          relative = FALSE
+        }
+      }
 
       # Because object$uri will always return an absolute URI, we need to
       # make it relative to the group's URI before adding it to the group

--- a/man/TileDBGroup.Rd
+++ b/man/TileDBGroup.Rd
@@ -168,7 +168,7 @@ basename of the object.
 \subsection{Method \code{add_member()}}{
 Add new member to the group.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBGroup$add_member(object, name = NULL, relative = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBGroup$add_member(object, name = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/tests/testthat/test_TileDBGroup.R
+++ b/tests/testthat/test_TileDBGroup.R
@@ -79,7 +79,7 @@ test_that("a group is portable when members are added with relative uris", {
 
   grp <- TileDBGroup$new(grp_uri1)
   a1 <- TileDBArray$new(create_empty_test_array(file.path(grp_uri1, "a1")))
-  grp$add_member(a1, relative = TRUE)
+  grp$add_member(a1)
 
   tiledb::tiledb_vfs_move_dir(olduri = grp_uri1, newuri = grp_uri2)
 


### PR DESCRIPTION
Detect if they a relative path is needed or not. Currently we use relative paths for everything but `tiledb://` URIs