### PR TITLE
Set default query layout to unordered

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.0.9003
+Version: 0.1.0.9004
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -47,6 +47,7 @@ TileDBArray <- R6::R6Class(
       args <- list(...)
       args$uri <- self$uri
       args$query_type <- "READ"
+      args$query_layout <- "UNORDERED"
       do.call(tiledb::tiledb_array, args)
     },
 


### PR DESCRIPTION
Set the default query layout to `UNORDERED` for improved read performance with sparse arrays.