### PR TITLE
Selective Seurat Assay Conversions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.0.9005
+Version: 0.1.0.9006
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,3 +25,5 @@ See [TileDB 2.8 release notes](https://github.com/TileDB-Inc/TileDB/releases/tag
 
 * added a `NEWS.md` file to track changes to the package
 * the *fs* package is now a dependency
+* `SCGroup`'s `from_seurat_assay()` method gained two new arguments: `layers`, to specify which Seurat `Assay` slots should be ingested, and `var`, to control whether feature-level metadata is ingested
+* `SCGroup`'s `from_seurat_assay()` method will no longer ingest the `data` slot if it is identical to `counts`

--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -144,7 +144,7 @@ SCGroup <- R6::R6Class(
     #'
     #' ## Annotations
     #'
-    #' Cell- and feature-level annotatations are stored in the `obs` and `var`
+    #' Cell- and feature-level annotations are stored in the `obs` and `var`
     #' arrays, respectively. These arrays are _always_ created during the
     #' initial ingestion in order to maintain the full set of cell and feature
     #' identifiers in the array dimension.

--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -154,7 +154,11 @@ SCGroup <- R6::R6Class(
     #' Variable features in the `var.features` slot are maintained by creating a
     #' `highly_variable` attribute in `var` that records `1` or `0` for each
     #' feature indicating whether it was a variable feature or not.
+    #'
     #' @param object A [`SeuratObject::Assay`] object
+    #' @param var Should the `Assay`'s' feature-level annotations be ingested
+    #' into the `var` array? If `FALSE` and the `var` array does not yet exist
+    #' then `var` is created as an array with 0 attributes.
     #' @param obs An optional `data.frame` containing annotations for
     #' cell/sample-level observations. If no annotations are provided and the
     #' `obs` array doesn't yet exist on disk, an array with 0 attributes is
@@ -192,14 +196,12 @@ SCGroup <- R6::R6Class(
           col.name = "highly_variable"
         )
       }
-      self$var$from_dataframe(object[[]], index_col = "var_id")
-      if (is.null(self$get_member("var"))) {
-        self$add_member(self$var, name = "var")
-      }
 
-      assay_slots <- c("counts", "data")
-      if (seurat_assay_has_scale_data(object)) {
-        assay_slots <- c(assay_slots, "scale.data")
+      if (var) {
+        self$var$from_dataframe(object[[]], index_col = "var_id")
+        if (is.null(self$get_member("var"))) {
+          self$add_member(self$var, name = "var")
+        }
       }
 
       assay_mats <- mapply(

--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -141,7 +141,15 @@ SCGroup <- R6::R6Class(
     #' @description Convert a Seurat Assay to a TileDB-backed sc_group.
     #'
     #' @details
-    #' ## On-Disk Format
+    #'
+    #' ## Annotations
+    #'
+    #' Cell- and feature-level annotatations are stored in the `obs` and `var`
+    #' arrays, respectively. These arrays are _always_ created during the
+    #' initial ingestion in order to maintain the full set of cell and feature
+    #' identifiers in the array dimension.
+    #'
+    #' ## Variable features
     #'
     #' Variable features in the `var.features` slot are maintained by creating a
     #' `highly_variable` attribute in `var` that records `1` or `0` for each

--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -142,6 +142,18 @@ SCGroup <- R6::R6Class(
     #'
     #' @details
     #'
+    #' ## Assay data
+    #'
+    #' The [`SeuratObject::Assay`] class stores different transformations of an
+    #' assay in the `counts`, `data`, and `scale.data` slots. Data from each of
+    #' these slots is ingested into a separate layer of the `X` group, named for
+    #' the corresponding slot.
+    #'
+    #' By default *Seurat* populates the `data` slot with a reference to the
+    #' same data stored in `counts`. To avoid ingesting redundant data, we check
+    #' to see if `counts` and `data` are identical and skip the `data` slot if
+    #' they are.
+    #'
     #' ## Annotations
     #'
     #' Cell- and feature-level annotations are stored in the `obs` and `var`
@@ -223,6 +235,16 @@ SCGroup <- R6::R6Class(
         MoreArgs = list(object = object),
         SIMPLIFY = FALSE
       )
+
+      # Don't ingest the 'data' layer if it's identical to the 'counts'
+      if (identical(assay_mats$counts, assay_mats$data)) {
+        assay_mats$data <- NULL
+        if (self$verbose) {
+          message(
+            "Skipping ingestion of 'data' because it is identical to 'counts'"
+          )
+        }
+      }
 
       # create a list of non-empty dgTMatrix objects
       assay_mats <- lapply(assay_mats, FUN = as, Class = "dgTMatrix")

--- a/R/TileDBGroup.R
+++ b/R/TileDBGroup.R
@@ -323,25 +323,17 @@ TileDBGroup <- R6::R6Class(
       x[x$TYPE %in% type, , drop = FALSE]
     },
 
-    format_arrays = function() {
-      arrays <- names(self$arrays)
-      if (!is_empty(arrays)) {
-        cat("  arrays:", string_collapse(arrays), "\n")
-      }
-    },
-
-    format_groups = function() {
-      groups <- basename(self$list_objects(type = "GROUP")$URI)
-      if (!is_empty(groups)) {
-        cat("  groups:", string_collapse(groups), "\n")
+    format_members = function() {
+      members <- names(self$members)
+      if (!is_empty(members)) {
+        cat("  members:", string_collapse(members), "\n")
       }
     },
 
     group_print = function() {
       cat("  uri:", self$uri, "\n")
       if (self$group_exists()) {
-        private$format_arrays()
-        private$format_groups()
+        private$format_members()
       }
     }
   )

--- a/man/SCGroup.Rd
+++ b/man/SCGroup.Rd
@@ -106,7 +106,12 @@ array group is created.
 \subsection{Method \code{from_seurat_assay()}}{
 Convert a Seurat Assay to a TileDB-backed sc_group.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SCGroup$from_seurat_assay(object, obs = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SCGroup$from_seurat_assay(
+  object,
+  obs = NULL,
+  var = TRUE,
+  layers = c("counts", "data", "scale.data")
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -115,12 +120,29 @@ Convert a Seurat Assay to a TileDB-backed sc_group.
 \item{\code{object}}{A \code{\link[SeuratObject:Assay-class]{SeuratObject::Assay}} object}
 
 \item{\code{obs}}{An optional \code{data.frame} containing annotations for
-cell/sample-level observations.}
+cell/sample-level observations. If no annotations are provided and the
+\code{obs} array doesn't yet exist, an array with 0 attributes is
+created.}
+
+\item{\code{var}}{Should the \code{Assay}'s' feature-level annotations be ingested
+into the \code{var} array? If \code{FALSE} and the \code{var} array does not yet exist
+then \code{var} is created as an array with 0 attributes.}
+
+\item{\code{layers}}{A vector of assay layer names to ingest. Must be some
+combination of \code{"counts"}, \code{"data"}, \code{"scale.data"}.}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Details}{
-\subsection{On-Disk Format}{
+\subsection{Annotations}{
+
+Cell- and feature-level annotatations are stored in the \code{obs} and \code{var}
+arrays, respectively. These arrays are \emph{always} created during the
+initial ingestion in order to maintain the full set of cell and feature
+identifiers in the array dimension.
+}
+
+\subsection{Variable features}{
 
 Variable features in the \code{var.features} slot are maintained by creating a
 \code{highly_variable} attribute in \code{var} that records \code{1} or \code{0} for each

--- a/man/SCGroup.Rd
+++ b/man/SCGroup.Rd
@@ -134,9 +134,22 @@ combination of \code{"counts"}, \code{"data"}, \code{"scale.data"}.}
 \if{html}{\out{</div>}}
 }
 \subsection{Details}{
+\subsection{Assay data}{
+
+The \code{\link[SeuratObject:Assay-class]{SeuratObject::Assay}} class stores different transformations of an
+assay in the \code{counts}, \code{data}, and \code{scale.data} slots. Data from each of
+these slots is ingested into a separate layer of the \code{X} group, named for
+the corresponding slot.
+
+By default \emph{Seurat} populates the \code{data} slot with a reference to the
+same data stored in \code{counts}. To avoid ingesting redundant data, we check
+to see if \code{counts} and \code{data} are identical and skip the \code{data} slot if
+they are.
+}
+
 \subsection{Annotations}{
 
-Cell- and feature-level annotatations are stored in the \code{obs} and \code{var}
+Cell- and feature-level annotations are stored in the \code{obs} and \code{var}
 arrays, respectively. These arrays are \emph{always} created during the
 initial ingestion in order to maintain the full set of cell and feature
 identifiers in the array dimension.

--- a/man/TileDBGroup.Rd
+++ b/man/TileDBGroup.Rd
@@ -168,7 +168,7 @@ basename of the object.
 \subsection{Method \code{add_member()}}{
 Add new member to the group.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TileDBGroup$add_member(object, name = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TileDBGroup$add_member(object, name = NULL, relative = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/tests/testthat/test_SCGroup_Seurat.R
+++ b/tests/testthat/test_SCGroup_Seurat.R
@@ -290,7 +290,7 @@ test_that("individual layers can be added or updated", {
   SeuratObject::Key(assay) <- "RNA"
 
   scgroup <- SCGroup$new(uri, verbose = TRUE)
-  scgroup$from_seurat_assay(assay, layers = "counts")
+  scgroup$from_seurat_assay(assay)
 
   # only counts was created
   expect_equal(names(scgroup$members$X$members), "counts")

--- a/vignettes/updates.Rmd
+++ b/vignettes/updates.Rmd
@@ -1,0 +1,159 @@
+---
+title: "Selective Updates"
+description: >
+  How to selectivley update components of an SCGroup.
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Updates}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+# Setup
+
+```{r setup}
+library(tiledbsc)
+library(SeuratObject)
+```
+
+# Overview
+
+While *tiledbsc* is currently focused on facilitating the storage and retrieval of complete Seurat/Bioconductor datasets, it is possible to selectively update specific components of an existing `SCGroup`.
+
+# Create the initial dataset
+
+As in the Introduction we'll use the `pbmc_small` dataset from the *SeuratObject* package.
+
+```{r}
+data("pbmc_small", package = "SeuratObject")
+pbmc_small
+```
+
+
+We'll start by creating a Seurat `Assay` object that contains only raw RNA counts
+
+```{r}
+pbmc_small_rna <- CreateAssayObject(
+  counts = GetAssayData(pbmc_small[["RNA"]], "counts")
+)
+
+Key(pbmc_small_rna) <- Key(pbmc_small[["RNA"]])
+```
+
+and then ingest this into a new `SCGroup` on disk:
+
+```{r, include = FALSE}
+scgroup <- SCGroup$new(uri = file.path(tempdir(), "pbmc_small_rna"))
+scgroup$from_seurat_assay(pbmc_small_rna)
+scgroup
+```
+
+This performed the following operations:
+
+- created groups `X`, `obsm`, `varm`, `obsp`, `varp`, and `misc`
+- created array, `obs`, with a single dimension containing all cell names and 0 attributes (because Seurat `Assay` objects do not contain cell-level metadata)
+- created array, `var`, with a single dimension containing all feature names and 0 attributes (because the feature-level metadata was empty)
+- created array `counts` within the `X` group and ingested all data from `pbmc_small_rna`'s `counts` slot
+
+Printing out the `X` group, we can see it contains only a single member, `counts`.
+
+```{r}
+scgroup$X
+```
+
+*Note: A Seurat `Assay` instantiated with data passed to the `counts` argument will store a reference to the same matrix in both the `counts` and `data` slots (i.e., `GetAssayData(pbmc_small_rna, "counts")` and `GetAssayData(pbmc_small_rna, "data")`). To avoid redundantly storing data on disk, *tiledbsc* only ingests data from `data` when it is not identical to `counts`.*
+
+# Add new layers for normalized and scaled data
+
+Now let's populate `pbmc_small_rna`'s `counts` slot with normalized counts.
+
+```{r}
+pbmc_small_rna <- SetAssayData(
+  pbmc_small_rna,
+  slot = "data",
+  new.data = GetAssayData(pbmc_small[["RNA"]], "data")
+)
+
+pbmc_small_rna
+```
+
+At this point, `counts` and `data` contain different transformations of the same matrix but only the `counts` data has been written to disk.
+
+We could simply rerun `scgroup$from_seurat_assay(pbmc_small_rna)` to update the `SCGroup` and ingest the normalized counts matrix into `X/data`, however, this
+would perform another full conversion of the entire `Assay` object. As a result, data from the `counts` slot would be *re-ingested* into `X/counts` and feature-level metadata would be re-ingested into `var`.
+
+To avoid these redudndant ingestions, use the `layers` argument to specify which of the assay slots (`counts`, `data`, or `scale.data`) should be ingested. We also set `var = FALSE` to prevent re-ingestion of the feature-level metadata since it hasn't changed.
+
+```{r}
+scgroup$from_seurat_assay(pbmc_small_rna, layers = "data", var = FALSE)
+```
+
+Printing out the `X` group again reveals that it now contains 2 members: `counts` and `data`.
+
+```{r}
+scgroup$X
+```
+
+Let's repeat this process for the scaled/centered version of the data that's stored in the `scale.data` slot.
+
+```{r}
+pbmc_small_rna <- SetAssayData(
+  pbmc_small_rna,
+  slot = "scale.data",
+  new.data = GetAssayData(pbmc_small[["RNA"]], "scale.data")
+)
+
+scgroup$from_seurat_assay(pbmc_small_rna, layers = "scale.data", var = FALSE)
+scgroup$X
+```
+
+The `X` group now contains 3 arrays, each of which has only been written to a single time. We can verify this by counting the number of fragments contained within any of individual arrays:
+
+```{r}
+scgroup$X$members$count$fragment_count()
+```
+
+TileDB creates a new fragment each time a write is performed, so 1 fragment confirms the array has been written to only once.
+
+# Update an existing layer
+
+If the data in your Seurat `Assay` _has_ changed since it was ingested into TileDB, you can follow the same basic process to update the array.
+
+Here, we'll aritifically shift all of the values in the `scale.data` slot by 1 and then re-ingest the updated data into the `scale.data` layer on disk:
+
+```{r}
+pbmc_small_rna <- SetAssayData(
+  pbmc_small_rna,
+  slot = "scale.data",
+  new.data = GetAssayData(pbmc_small[["RNA"]], "scale.data") + 1
+)
+
+scgroup$from_seurat_assay(pbmc_small_rna, layers = "scale.data", var = FALSE)
+```
+
+Now let's verify that number of fragments in each `X`'s layers:
+
+```{r}
+sapply(
+  names(scgroup$X$members),
+  function(x) scgroup$X$members[[x]]$fragment_count()
+)
+```
+
+
+# Session
+
+```{r}
+sessionInfo()
+```
+
+```{r cleanup, include=FALSE}
+tiledb::tiledb_vfs_remove_dir(scgroup$uri)
+```


### PR DESCRIPTION
This updates `SCGroup`'s `from_seurat_assay()` method to provide more control over what data is ingested/updated. 

## API Changes

Previous, every call to `from_seurat_assay()` would ingest all components of a Seurat `Assay`. This is still the default behavior. However, with the new `layers` argument users can specify a subset of the available `counts`, `data`, and `scale.data` slots should be ingested. 

It's also now possible to prevent re-ingesting feature-level metadata (it's _always_ ingested when the `SCGroup` is first created) by setting `var = FALSE`. 

## Other changes

- `from_seurat_assay()` method will no longer ingest the `data` slot if it is identical to `counts`
- added a new vignette called *Updates* that describes this behavior in greater detail

