### PR TITLE
Support config and context parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.0.9004
+Version: 0.1.0.9005
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/R/SCDataset.R
+++ b/R/SCDataset.R
@@ -22,8 +22,10 @@ SCDataset <- R6::R6Class(
     #'
     #' @param uri URI of the TileDB group
     #' @param verbose Print status messages
-    initialize = function(uri, verbose = TRUE) {
-      super$initialize(uri, verbose)
+    #' @param config optional configuration
+    #' @param ctx optional tiledb context
+    initialize = function(uri, verbose = TRUE, config = NULL, ctx = NULL) {
+      super$initialize(uri, verbose, config, ctx)
 
       if ("misc" %in% names(self$members)) {
         self$misc <- self$get_member("misc")
@@ -70,7 +72,7 @@ SCDataset <- R6::R6Class(
       for (assay in assays) {
         assay_object <- object[[assay]]
         assay_uri <- file_path(self$uri, paste0("scgroup_", assay))
-        scgroup <- SCGroup$new(assay_uri, verbose = self$verbose)
+        scgroup <- SCGroup$new(assay_uri, verbose = self$verbose, config = self$config, context = self$context)
         scgroup$from_seurat_assay(assay_object, obs = object[[]])
         self$add_member(scgroup, name = assay)
       }
@@ -204,8 +206,8 @@ SCDataset <- R6::R6Class(
       names(scgroup_uris) <- sub("scgroup_", "", names(scgroup_uris), fixed = TRUE)
 
       c(
-        lapply(scgroup_uris, SCGroup$new, verbose = self$verbose),
-        lapply(misc_uri, TileDBGroup$new, verbose = self$verbose)
+        lapply(scgroup_uris, SCGroup$new, verbose = self$verbose, config = self$config, context = self$context),
+        lapply(misc_uri, TileDBGroup$new, verbose = self$verbose, config = self$config, context = self$context)
       )
     },
 

--- a/R/SCDataset.R
+++ b/R/SCDataset.R
@@ -72,7 +72,7 @@ SCDataset <- R6::R6Class(
       for (assay in assays) {
         assay_object <- object[[assay]]
         assay_uri <- file_path(self$uri, paste0("scgroup_", assay))
-        scgroup <- SCGroup$new(assay_uri, verbose = self$verbose, config = self$config, context = self$context)
+        scgroup <- SCGroup$new(assay_uri, verbose = self$verbose, config = self$config, ctx = self$context)
         scgroup$from_seurat_assay(assay_object, obs = object[[]])
         self$add_member(scgroup, name = assay)
       }
@@ -206,8 +206,8 @@ SCDataset <- R6::R6Class(
       names(scgroup_uris) <- sub("scgroup_", "", names(scgroup_uris), fixed = TRUE)
 
       c(
-        lapply(scgroup_uris, SCGroup$new, verbose = self$verbose, config = self$config, context = self$context),
-        lapply(misc_uri, TileDBGroup$new, verbose = self$verbose, config = self$config, context = self$context)
+        lapply(scgroup_uris, SCGroup$new, verbose = self$verbose, config = self$config, ctx = self$context),
+        lapply(misc_uri, TileDBGroup$new, verbose = self$verbose, config = self$config, ctx = self$context)
       )
     },
 

--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -43,10 +43,14 @@ SCGroup <- R6::R6Class(
     #'
     #' @param uri URI of the TileDB group
     #' @param verbose Print status messages
+    #' @param config optional configuration
+    #' @param ctx optional tiledb context
     initialize = function(
       uri,
-      verbose = TRUE) {
-      super$initialize(uri, verbose)
+      verbose = TRUE,
+      config = NULL,
+      context = NULL) {
+      super$initialize(uri, verbose, config, context)
 
       if ("obs" %in% names(self$members)) {
         self$obs <- self$get_member("obs")

--- a/R/SCGroup.R
+++ b/R/SCGroup.R
@@ -49,8 +49,8 @@ SCGroup <- R6::R6Class(
       uri,
       verbose = TRUE,
       config = NULL,
-      context = NULL) {
-      super$initialize(uri, verbose, config, context)
+      ctx = NULL) {
+      super$initialize(uri, verbose, config, ctx)
 
       if ("obs" %in% names(self$members)) {
         self$obs <- self$get_member("obs")

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -9,7 +9,7 @@ TileDBArray <- R6::R6Class(
     verbose = TRUE,
     #' @field optional configuration
     config = NULL,
-    #' @field optional tiledb context'
+    #' @field optional tiledb context
     ctx = NULL,
 
     #' @description Create a new TileDBArray object.

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -7,7 +7,7 @@ TileDBArray <- R6::R6Class(
   public = list(
     uri = NULL,
     verbose = TRUE,
-    #' @field optional configuration'
+    #' @field optional configuration
     config = NULL,
     #' @field optional tiledb context'
     ctx = NULL,

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -56,7 +56,7 @@ TileDBArray <- R6::R6Class(
     #' @description Check if the array exists.
     #' @return TRUE if the array exists, FALSE otherwise.
     array_exists = function() {
-      tiledb::tiledb_object_type(self$uri, ctx <- self$ctx) == "ARRAY"
+      tiledb::tiledb_object_type(self$uri, ctx = self$ctx) == "ARRAY"
     },
 
     #' @description Return a [`TileDBArray`] object

--- a/R/TileDBGroup.R
+++ b/R/TileDBGroup.R
@@ -10,14 +10,32 @@ TileDBGroup <- R6::R6Class(
     members = list(),
     #' @field verbose Whether to print verbose output
     verbose = TRUE,
+    #' @field optional config'
+    config = NULL,
+        #' @field optional tiledb context'
+    ctx = NULL,
 
     #' @description Create a new TileDBGroup object.
     #' @param uri TileDB array URI
     #' @param verbose Print status messages
-    initialize = function(uri, verbose = TRUE) {
+    #' @param config optional configuration
+    #' @param ctx optional tiledb context
+    initialize = function(uri, verbose = TRUE, config = NULL, ctx = NULL) {
       if (missing(uri)) stop("A `uri` must be specified")
       self$uri <- uri
       self$verbose <- verbose
+      self$config <- config
+      self$ctx <- ctx
+
+      if (!is.null(config) && !is.null(ctx)) stop("Cannot pass a config and context, please choose one")
+
+      if (!is.null(self$config)) {
+        self$ctx <- tiledb::tiledb_ctx(self$config)
+      }
+      
+      if (is.null(self$ctx)) {
+        self$ctx <- tiledb::tiledb_get_context()
+      }
 
       if (self$group_exists()) {
         if (self$verbose) {
@@ -34,7 +52,7 @@ TileDBGroup <- R6::R6Class(
         private$create_group()
       }
 
-      private$group <- tiledb::tiledb_group(self$uri)
+      private$group <- tiledb::tiledb_group(self$uri, ctx = self$ctx)
       private$group_close()
 
       # Instatiate objects for existing members
@@ -56,7 +74,7 @@ TileDBGroup <- R6::R6Class(
     #' @description Check if the group exists.
     #' @return TRUE if the group exists, FALSE otherwise.
     group_exists = function() {
-      tiledb::tiledb_object_type(self$uri) == "GROUP"
+      tiledb::tiledb_object_type(self$uri, ctx = self$ctx) == "GROUP"
     },
 
     #' @description Return a [`tiledb_group`] object
@@ -65,6 +83,7 @@ TileDBGroup <- R6::R6Class(
     tiledb_group = function(...) {
       args <- list(...)
       args$uri <- self$uri
+      args$ctx <- self$ctx
       do.call(tiledb::tiledb_group, args)
     },
 
@@ -145,10 +164,10 @@ TileDBGroup <- R6::R6Class(
     #' @description List the members of the group.
     #' @param type The type of member to list, either `"ARRAY"`, or `"GROUP"`.
     #' By default all member types are listed.
-    #' @return A `data.frame` with columns `URI` and `TYPE`.
+    #' @return A `data.frame` with columns `URI` and `TYPE`, `NAME`.
     list_members = function(type = NULL) {
       count <- self$count_members()
-      members <- data.frame(TYPE = character(count), URI = character(count))
+      members <- data.frame(TYPE = character(count), URI = character(count), NAME = character(count))
       if (count == 0) return(members)
 
       on.exit(private$group_close())
@@ -263,7 +282,7 @@ TileDBGroup <- R6::R6Class(
       if (self$verbose) {
         message(sprintf("Creating new %s at '%s'", self$class(), self$uri))
       }
-      tiledb::tiledb_group_create(self$uri)
+      tiledb::tiledb_group_create(self$uri, ctx = self$ctx)
     },
 
     group_open = function(mode) {

--- a/R/TileDBGroup.R
+++ b/R/TileDBGroup.R
@@ -164,7 +164,7 @@ TileDBGroup <- R6::R6Class(
     #' @description List the members of the group.
     #' @param type The type of member to list, either `"ARRAY"`, or `"GROUP"`.
     #' By default all member types are listed.
-    #' @return A `data.frame` with columns `URI` and `TYPE`, `NAME`.
+    #' @return A `data.frame` with columns `URI`, `TYPE`, and `NAME`.
     list_members = function(type = NULL) {
       count <- self$count_members()
       members <- data.frame(TYPE = character(count), URI = character(count), NAME = character(count))

--- a/tests/testthat/test_TileDBGroup.R
+++ b/tests/testthat/test_TileDBGroup.R
@@ -17,10 +17,18 @@ test_that("members can be added and retrieved from a new group", {
   expect_is(grp$tiledb_group(), "tiledb_group")
 
   expect_equal(grp$count_members(), 0)
+
   objs <- grp$list_objects()
   expect_is(objs, "data.frame")
   expect_equal(nrow(objs), 0)
-  expect_identical(grp$list_members(), objs)
+
+  mems <- grp$list_members()
+  expect_is(mems, "data.frame")
+  expect_equal(nrow(mems), 0)
+
+  # members and objects are not identical --
+  # members is a data.frame with (type, uri, name)
+  # objects is a data.frame with (type, uri)
 
   # create sub-objects
   a1 <- TileDBArray$new(


### PR DESCRIPTION
This lets users manually set tiledb parameters for access the data. Previously this was supported by setting the TileDB-R default context. This increases the flexibility for users by allowing config or context to be passed in.