### PR TITLE
Use CZI default parameters for X/obs/var

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.0.9008
+Version: 0.1.0.9009
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,9 +16,12 @@ See [TileDB 2.8 release notes](https://github.com/TileDB-Inc/TileDB/releases/tag
 - `get_array()` has been replaced with `get_member()` which add a `type` argument to filter by object type
 - gain the following methods: `count_members()`, `list_members()`, `list_member_uris()`, and `add_member()`
 
-### Other
+### SCGroup
 
 - the `scgroup_uris` argument has been dropped from `SCDataset`'s initialize method (`add_member()` should now be used instead to add additional `SCGroup`s)
+
+### SCDataset
+
 - `SCDataset`'s `scgroups` field is now an active binding that filters `members` for `SCGroup` objects
 
 ## Other changes
@@ -30,3 +33,4 @@ See [TileDB 2.8 release notes](https://github.com/TileDB-Inc/TileDB/releases/tag
 * Internally group members are now added with names
 * New internal `TileDBURI` class for handling  various URI formats
 * The `uri` field for all TileDB(Array|Group)-based classes is now an active binding that retrieves the URI from the private `tiledb_uri` field
+* Several default parameters have been changed to store the the `X`, `obs`, and `var` arrays more efficiently on disk (#50)

--- a/R/AnnotationArray.R
+++ b/R/AnnotationArray.R
@@ -36,16 +36,7 @@ AnnotationArray <- R6::R6Class(
         "'x' must contain column names matching the supplied index column(s)"
         = all(index_cols %in% colnames(x))
       )
-
-      if (self$verbose) {
-        msg <- sprintf(
-          "Creating new %s array with index [%s] at '%s'",
-          self$class(),
-          paste0(index_cols, collapse = ","),
-          self$uri
-        )
-        message(msg)
-      }
+      private$log_array_creation(index_cols)
 
       tiledb::fromDataFrame(
         obj = x,
@@ -61,12 +52,33 @@ AnnotationArray <- R6::R6Class(
     # @description Ingest assay/annotation data into the TileDB array
     # @param x A [`data.frame`]
     ingest_data = function(x) {
-      if (self$verbose) {
-        message(glue::glue("Ingesting {self$class()} data into: {self$uri}"))
-      }
+      private$log_array_ingestion()
       tdb_array <- tiledb::tiledb_array(self$uri, query_type = "WRITE")
       tdb_array[] <- x
       tiledb::tiledb_array_close(tdb_array)
+    },
+
+    log_array_creation = function(index_cols) {
+      if (self$verbose) {
+        msg <- sprintf(
+          "Creating new %s array with index [%s] at '%s'",
+          self$class(),
+          paste0(index_cols, collapse = ","),
+          self$uri
+        )
+        message(msg)
+      }
+    },
+
+    log_array_ingestion = function() {
+      if (self$verbose) {
+        msg <- sprintf(
+          "Ingesting %s data into: %s",
+          self$class,
+          self$uri
+        )
+        message(msg)
+      }
     }
   )
 )

--- a/R/AnnotationArray.R
+++ b/R/AnnotationArray.R
@@ -74,7 +74,7 @@ AnnotationArray <- R6::R6Class(
       if (self$verbose) {
         msg <- sprintf(
           "Ingesting %s data into: %s",
-          self$class,
+          self$class(),
           self$uri
         )
         message(msg)

--- a/R/AnnotationDataframe.R
+++ b/R/AnnotationDataframe.R
@@ -32,7 +32,13 @@ AnnotationDataframe <- R6::R6Class(
       # convert rownames to a column
       x[[index_col]] <- rownames(x)
       if (!self$array_exists()) {
-        private$create_empty_array(x, index_col)
+        # TODO: Replace with configurable SOMAOptions class
+        capacity <- switch(basename(self$uri),
+          obs = 256L,
+          var = 2048L,
+          10000L
+        )
+        private$create_empty_array(x, index_col, capacity = capacity)
       } else {
         message(sprintf("Updating existing %s at '%s'", self$class(), self$uri))
       }

--- a/R/AssayMatrix.R
+++ b/R/AssayMatrix.R
@@ -136,11 +136,13 @@ AssayMatrix <- R6::R6Class(
         tiledb::tiledb_filter("RLE")
       )
 
+      # TODO: Make zstd compression level configurable, currently using same
+      # default as core: https://github.com/TileDB-Inc/TileDB/blob/56644c1e94fcba26d07a608112fdcdf3fd120ba8/tiledb/sm/filter/compression_filter.h#L154
       tiledb::filter_list(tdb_dims[[2]]) <- tiledb::tiledb_filter_list(
         tiledb::tiledb_filter_set_option(
           object = tiledb::tiledb_filter("ZSTD"),
           option = "COMPRESSION_LEVEL",
-          value = 22L
+          value = 3L
         )
       )
 
@@ -148,7 +150,7 @@ AssayMatrix <- R6::R6Class(
       tdb_attr_filter <- tiledb::tiledb_filter_set_option(
         object = tiledb::tiledb_filter("ZSTD"),
         option = "COMPRESSION_LEVEL",
-        value = 1L
+        value = 3L
       )
 
       tdb_attrs <- mapply(

--- a/R/AssayMatrix.R
+++ b/R/AssayMatrix.R
@@ -111,7 +111,7 @@ AssayMatrix <- R6::R6Class(
       index_cols = c("obs_id", "var_id"),
       cell_order = "ROW_MAJOR",
       tile_order = "ROW_MAJOR",
-      capacity = 10000) {
+      capacity = 100000) {
 
       # determine appropriate type for each attribute
       value_cols <- setdiff(colnames(x), index_cols)

--- a/inst/bench/run-benchmarks.R
+++ b/inst/bench/run-benchmarks.R
@@ -1,4 +1,4 @@
-devtools::load_all()
+library(tiledbsc)
 library(lobstr)
 library(tiledb)
 library(SeuratObject)

--- a/inst/bench/run-benchmarks.R
+++ b/inst/bench/run-benchmarks.R
@@ -48,7 +48,7 @@ datasets <- AvailableData()
 datasets <- subset(datasets, Version >= package_version("2.0.0"))
 
 # skip datasets that cause errors
-blacklist <- c(
+blocklist <- c(
   # Not a validObject(): no slot of name "images" for this object of class "Seurat"
   # I believe this error is specific to datasets with Versions < 2.0.0
   "humancortexref.SeuratData",
@@ -78,8 +78,8 @@ benchmarks <- data.frame(
 # main -------------------------------------------------------------------------
 for (ds_name in rownames(datasets)) {
   message(sprintf("Dataset: %s", ds_name))
-  if (ds_name %in% blacklist) {
-    message(sprintf("..skipping blacklisted dataset: %s", ds_name))
+  if (ds_name %in% blocklist) {
+    message(sprintf("..skipping blocklisted dataset: %s", ds_name))
     next
   }
 

--- a/inst/bench/run-benchmarks.R
+++ b/inst/bench/run-benchmarks.R
@@ -1,0 +1,134 @@
+devtools::load_all()
+library(lobstr)
+library(tiledb)
+library(SeuratObject)
+
+# devtools::install_github('satijalab/seurat-data')
+library(SeuratData)
+
+# parameters -------------------------------------------------------------------
+
+# where the new arrays will be stored
+array_dir <- "dev/data/arrays"
+
+# where the benchmark results will be stored
+output_dir <- "dev/data/benchmarks"
+
+# should the new arrays be deleted after the benchmark?
+clean <- FALSE
+
+# should datasets be installed if they are not already?
+install_missing <- TRUE
+
+
+# outputs ----------------------------------------------------------------------
+
+# create the output file
+output_metadata <- sprintf(
+  "%s_tiledbsc%s_tiledb%s",
+  format(Sys.time(),"%Y%m%d-%H%M"),
+  packageVersion("tiledbsc"),
+  packageVersion("tiledb")
+)
+
+output_name <- paste0("ingestion-benchmarks_", output_metadata, ".csv")
+
+output_file <- file.path(output_dir, output_name)
+
+# create parent directory using file metadata
+array_dir <- file.path(array_dir, output_metadata)
+dir.create(array_dir, showWarnings = FALSE, recursive = TRUE)
+dir.create(output_dir, showWarnings = FALSE, recursive = TRUE)
+
+# setup datasets ---------------------------------------------------------------
+datasets <- AvailableData()
+
+# remove datasets with Versions < 2.0.0 to avoid the following error:
+# Not a validObject(): no slot of name "images" for this object of class "Seurat"
+datasets <- subset(datasets, Version >= package_version("2.0.0"))
+
+# skip datasets that cause errors
+blacklist <- c(
+  # Not a validObject(): no slot of name "images" for this object of class "Seurat"
+  # I believe this error is specific to datasets with Versions < 2.0.0
+  "humancortexref.SeuratData",
+  "kidneyref.SeuratData",
+
+  # Datasets that are already installed but LoadData() errors with:
+  # Error: Could not find dataset '<>', please check manifest and try again
+  "bonemarrowref.SeuratData",
+
+  # Failed to download
+  "lungref.SeuratData"
+)
+
+# Temporarily subset
+datasets <- datasets[1:min(10L, nrow(datasets)),]
+
+# setup results ----------------------------------------------------------------
+
+# initialize results dataframe
+benchmarks <- data.frame(
+  size_memory = numeric(),
+  size_rds = numeric(),
+  size_tiledb = numeric(),
+  ingest_time = numeric()
+)
+
+# main -------------------------------------------------------------------------
+for (ds_name in rownames(datasets)) {
+  message(sprintf("Dataset: %s", ds_name))
+  if (ds_name %in% blacklist) {
+    message(sprintf("..skipping blacklisted dataset: %s", ds_name))
+    next
+  }
+
+  if (!datasets[ds_name, "Installed"]) {
+    skip <- FALSE
+    if (interactive()) {
+      if (menu(c("yes", "no"), sprintf("Install %s?", ds_name)) == 2) skip <- TRUE
+    } else {
+      if (!install_missing) skip <- TRUE
+    }
+
+    if (skip) {
+      message(sprintf("..skipping dataset not installed: %s", ds_name))
+      next
+    }
+
+    message(sprintf("..installing dataset '%s'", ds_name))
+    install_worked <- try(InstallData(ds_name), silent = TRUE)
+    if (inherits(install_worked, "try-error")) {
+      message(sprintf("..failed to install dataset '%s'", ds_name))
+      next
+    }
+  }
+
+  message("..loading dataset")
+  ds <- LoadData(ds_name)
+
+  uri <- file.path(array_dir, ds_name)
+  message(sprintf("..ingesting data into '%s'", uri))
+
+  ingest_start <- Sys.time()
+  scgroup <- SCGroup$new(uri = uri)
+  scgroup$from_seurat_assay(
+    object = ds[[DefaultAssay(ds)]],
+    obs = ds[[]]
+  )
+
+  benchmarks[ds_name, ] <- list(
+    size_memory = as.numeric(obj_size(ds)),
+    size_rds = tiledb_vfs_dir_size(system.file("data", package = ds_name)),
+    size_tiledb = tiledb_vfs_dir_size(uri),
+    ingest_time = as.numeric(difftime(Sys.time(), ingest_start, units = "secs"))
+  )
+
+  # write each time to avoid losing data on failures
+  write.csv(benchmarks, file = output_file, quote = FALSE)
+
+  if (clean) {
+    message(sprintf("..cleaning dataset '%s'", ds_name))
+    tiledb_vfs_remove_dir(uri)
+  }
+}

--- a/man/AssayMatrix.Rd
+++ b/man/AssayMatrix.Rd
@@ -88,7 +88,7 @@ Ingest assay data from a COO-formatted data frame
 \item{\code{x}}{a \code{\link{data.frame}}}
 
 \item{\code{index_cols}}{A column index, either numeric with a column index, or
-character with a column name, designating one or more index columns. All
+character with a column name, identifying the 2 index columns. All
 other columns are ingested as attributes.}
 }
 \if{html}{\out{</div>}}


### PR DESCRIPTION
Updates several tiledb parameters for the storage of `obs`, `var`, and `X` arrays (as discussed in #48). Also includes a few minor (internal) changes described below.

Changes to `X` arrays:

- increased capacity from 1e4 to 1e5
- offset filters include: double delta, bit width, and zstd
- use rle on first string dimension
- use zstd on second string dimension

Changes to annotation dataframes:
- `obs` capacity is 256
- `var` capacity is 2048

## Benchmarks

I compared the ingestion times and on-disk sizes with (`tiledbsc0.1.0.9009`) and without (`tiledbsc0.1.0.9007`) the above parameter changes for several different Seurat datasets provided by the *SeuratData* package.

Here are the sizes of the original `.rds` files

|dataset     |size_rds  |
|:-----------|:---------|
|cbmc        |35.30 MB  |
|ifnb        |41.91 MB  |
|ssHippo     |98.05 MB  |
|pbmcsca     |126.23 MB |
|hcabm40k    |187.54 MB |
|panc8       |286.05 MB |
|pbmc3k      |298.15 MB |
|thp1.eccite |321.10 MB |


Ingestion times:

|dataset     | tiledbsc0.1.0.9007| tiledbsc0.1.0.9009|change  |
|:-----------|------------------:|------------------:|:-------|
|cbmc        |              16.28|              10.57|35.09%  |
|ifnb        |              22.90|              18.47|19.36%  |
|ssHippo     |              49.01|              38.84|20.75%  |
|pbmcsca     |              79.25|              68.95|13.01%  |
|hcabm40k    |             171.96|             136.09|20.86%  |
|panc8       |             128.92|             117.16|9.12%   |
|pbmc3k      |               3.83|               4.48|-16.92% |
|thp1.eccite |             184.08|             179.19|2.66%   |

On-disk size:

|dataset     |tiledbsc0.1.0.9007 |tiledbsc0.1.0.9009 |change |
|:-----------|:------------------|:------------------|:------|
|cbmc        |67.45 MB           |40.88 MB           |39.39% |
|ifnb        |78.76 MB           |47.06 MB           |40.25% |
|ssHippo     |171.60 MB          |109.54 MB          |36.16% |
|pbmcsca     |276.76 MB          |190.66 MB          |31.11% |
|hcabm40k    |466.52 MB          |324.25 MB          |30.50% |
|panc8       |360.41 MB          |214.82 MB          |40.39% |
|pbmc3k      |17.58 MB           |9.57 MB            |45.55% |
|thp1.eccite |656.71 MB          |406.83 MB          |38.05% |


File-specific on-disk sizes:

|path                                                                    | tiledbsc0.1.0.9007| tiledbsc0.1.0.9009|change  |
|:-----------------------------------------------------------------------|------------------:|------------------:|:-------|
|panc8.SeuratData/X/counts/__fragments/.../d0.tdb                        |             53.62M|              4.05K|99.993% |
|thp1.eccite.SeuratData/X/counts/__fragments/.../d0.tdb                  |             72.02M|              5.44K|99.993% |
|pbmcsca.SeuratData/X/counts/__fragments/.../d0.tdb                      |             28.56M|              2.16K|99.993% |
|ssHippo.SeuratData/X/counts/__fragments/.../d0.tdb                      |             23.16M|              1.75K|99.993% |
|hcabm40k.SeuratData/X/counts/__fragments/.../d0.tdb                     |             41.75M|              3.16K|99.993% |
|ifnb.SeuratData/X/counts/__fragments/.../d0.tdb                         |             10.13M|                784|99.993% |
|cbmc.SeuratData/X/counts/__fragments/.../d0.tdb                         |              8.55M|                664|99.993% |
|pbmc3k.SeuratData/X/counts/__fragments/.../d0.tdb                       |              2.36M|                184|99.993% |
|hcabm40k.SeuratData/X/counts/__fragments/.../d1.tdb                     |             50.23M|            680.19K|98.678% |
|thp1.eccite.SeuratData/X/counts/__fragments/.../d1.tdb                  |             78.83M|              1.15M|98.547% |
|cbmc.SeuratData/X/counts/__fragments/.../d1.tdb                         |              9.17M|            139.08K|98.519% |
|ssHippo.SeuratData/X/counts/__fragments/.../d1.tdb                      |             24.57M|            377.14K|98.501% |
|pbmc3k.SeuratData/X/counts/__fragments/.../d1.tdb                       |              2.51M|             38.53K|98.500% |
|ifnb.SeuratData/X/counts/__fragments/.../d1.tdb                         |             10.89M|            568.48K|94.902% |
|pbmcsca.SeuratData/X/counts/__fragments/.../d1.tdb                      |             33.07M|              1.83M|94.453% |
|thp1.eccite.SeuratData/X/counts/__fragments/.../__fragment_metadata.tdb |            261.35K|             27.93K|89.314% |
|hcabm40k.SeuratData/X/counts/__fragments/.../__fragment_metadata.tdb    |            174.83K|              18.9K|89.192% |
|panc8.SeuratData/X/counts/__fragments/.../__fragment_metadata.tdb       |            236.84K|             27.46K|88.404% |
|pbmcsca.SeuratData/X/counts/__fragments/.../__fragment_metadata.tdb     |            126.72K|              15.4K|87.845% |
|ssHippo.SeuratData/X/counts/__fragments/.../__fragment_metadata.tdb     |             89.77K|             12.68K|85.878% |
|ifnb.SeuratData/X/counts/__fragments/.../__fragment_metadata.tdb        |             40.79K|              7.91K|80.596% |
|panc8.SeuratData/X/counts/__fragments/.../d1.tdb                        |             57.63M|             11.65M|79.786% |
|cbmc.SeuratData/X/counts/__fragments/.../__fragment_metadata.tdb        |             33.96K|              7.24K|78.672% |
|thp1.eccite.SeuratData/X/counts/__fragments/.../d0_var.tdb              |            643.37K|            210.61K|67.265% |
|hcabm40k.SeuratData/X/counts/__fragments/.../d0_var.tdb                 |            473.61K|            180.78K|61.830% |
|pbmc3k.SeuratData/X/counts/__fragments/.../__fragment_metadata.tdb      |             12.17K|              4.89K|59.840% |
|panc8.SeuratData/X/counts/__fragments/.../d0_var.tdb                    |            636.49K|            303.86K|52.261% |
|ssHippo.SeuratData/X/counts/__fragments/.../a0.tdb                      |             15.87M|              8.18M|48.456% |
|ifnb.SeuratData/X/counts/__fragments/.../d0_var.tdb                     |            244.48K|            129.79K|46.909% |
|thp1.eccite.SeuratData/X/counts/__fragments/.../a0.tdb                  |             76.83M|             42.13M|45.161% |
|ifnb.SeuratData/X/counts/__fragments/.../a0.tdb                         |              8.28M|              4.59M|44.625% |
|cbmc.SeuratData/X/counts/__fragments/.../a0.tdb                         |              6.38M|              3.61M|43.411% |
|ssHippo.SeuratData/X/counts/__fragments/.../d0_var.tdb                  |            388.06K|            226.55K|41.621% |
|hcabm40k.SeuratData/X/counts/__fragments/.../a0.tdb                     |             37.09M|             21.72M|41.439% |
|pbmcsca.SeuratData/X/counts/__fragments/.../d0_var.tdb                  |            545.63K|            322.65K|40.866% |
|pbmc3k.SeuratData/X/counts/__fragments/.../a0.tdb                       |              1.62M|              1.01M|37.456% |
|cbmc.SeuratData/X/counts/__fragments/.../d0_var.tdb                     |            310.26K|            201.78K|34.965% |
|pbmcsca.SeuratData/X/counts/__fragments/.../a0.tdb                      |              21.7M|             14.84M|31.601% |
|pbmc3k.SeuratData/X/counts/__fragments/.../d1_var.tdb                   |             10.01M|              7.84M|21.676% |
|panc8.SeuratData/X/counts/__fragments/.../d1_var.tdb                    |            154.99M|             127.8M|17.547% |
|panc8.SeuratData/X/counts/__fragments/.../a0.tdb                        |             76.18M|             64.66M|15.120% |
|pbmc3k.SeuratData/X/counts/__fragments/.../d0_var.tdb                   |            142.87K|            123.41K|13.622% |
|thp1.eccite.SeuratData/X/counts/__fragments/.../d1_var.tdb              |            396.34M|            343.09M|13.436% |
|ifnb.SeuratData/X/counts/__fragments/.../d1_var.tdb                     |             45.26M|             39.33M|13.108% |
|cbmc.SeuratData/X/counts/__fragments/.../d1_var.tdb                     |             39.62M|             34.77M|12.255% |
|hcabm40k.SeuratData/X/counts/__fragments/.../d1_var.tdb                 |            314.58M|            286.02M|9.079%  |
|pbmcsca.SeuratData/X/counts/__fragments/.../d1_var.tdb                  |            178.56M|            163.42M|8.478%  |
|ssHippo.SeuratData/X/counts/__fragments/.../d1_var.tdb                  |             98.91M|             95.02M|3.939%  |

## Other changes

- Fix `log_array_ingestion()`
- adds private methods for logging array creation/ingestion
