### PR TITLE
Release 0.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     R6,
     methods,
     Matrix,
-    tiledb (>= 0.12.0.2),
+    tiledb (>= 0.13.0),
     SeuratObject,
     jsonlite,
     glue,
@@ -50,7 +50,5 @@ Suggests:
     testthat (>= 3.0.0),
     SummarizedExperiment,
     SingleCellExperiment
-Remotes:
-    tiledb-inc/tiledb-r
 VignetteBuilder: knitr
 Config/testthat/edition: 2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.0.9010
+Version: 0.1.1
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# tiledbsc (development version)
+# tiledbsc 0.1.1
 
 tiledbsc now uses the enhanced Group API's introduced in TileDB v2.8 and TileDB-R 0.12.0.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,3 +35,4 @@ See [TileDB 2.8 release notes](https://github.com/TileDB-Inc/TileDB/releases/tag
 * The `uri` field for all TileDB(Array|Group)-based classes is now an active binding that retrieves the URI from the private `tiledb_uri` field
 * Several default parameters have been changed to store the the `X`, `obs`, and `var` arrays more efficiently on disk (#50)
 * Seurat cell identities are now stored in the `active_ident` attribute of the `obs` array (#56)
+* Require at least version 0.13.0 of tiledb-r to support retrieval of group names

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 tiledbsc now uses the enhanced Group API's introduced in TileDB v2.8 and TileDB-R 0.12.0.
 
-*Note: The next version of tiledbsc will migrate to the new SOMA-based naming scheme described [here](https://github.com/single-cell-data/matrix-api/issues/27).
+*Note: The next version of tiledbsc will migrate to the new SOMA-based naming scheme described [here](https://github.com/single-cell-data/matrix-api/issues/27).*
 
 ## On-disk changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 tiledbsc now uses the enhanced Group API's introduced in TileDB v2.8 and TileDB-R 0.12.0.
 
+*Note: The next version of tiledbsc will migrate to the new SOMA-based naming scheme described [here](https://github.com/single-cell-data/matrix-api/issues/27).
+
 ## On-disk changes
 
 Group-level metadata is now natively supported by TileDB so `TileDBGroup`-based classes no longer create nested `__tiledb_group_metadata` arrays for the purpose of storing group-level metadata.


### PR DESCRIPTION
This updates the package to 0.1.1. See [NEWS.md](https://github.com/TileDB-Inc/tiledbsc/blob/d2c70e1f637ad00b3fd338c7e5abccb8a3b3f393/NEWS.md) for all changes since previous release.

*Note: The next version of tiledbsc will migrate to the new SOMA-based naming scheme described [here](https://github.com/single-cell-data/matrix-api/issues/27).*

## Other changes

Also updates the required version of tiledb-r to its latest CRAN release, 0.13.0 (which includes necessary support for retrieving group names), and has been removed from the `DESCRIPTION`'s `Remotes` field. 

*Note: Updating tiledb-r to 0.13.0 isn't strictly necessary as long as you have at least 0.12.0.2 installed.*