### PR TITLE
Improve handling of Seurat objects with empty cell identities

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # tiledbsc 0.1.2
 
-Improve handling of Seurat objects with empty cell identities.
+Improve handling of Seurat objects with empty cell identities (#58).
 
 # tiledbsc 0.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# tiledbsc 0.1.2
+
+Improve handling of Seurat objects with empty cell identities.
+
 # tiledbsc 0.1.1
 
 tiledbsc now uses the enhanced Group API's introduced in TileDB v2.8 and TileDB-R 0.12.0.

--- a/R/SCDataset.R
+++ b/R/SCDataset.R
@@ -155,8 +155,11 @@ SCDataset <- R6::R6Class(
       obs_df <- self$scgroups[[1]]$obs$to_dataframe()
 
       # retain cell identities before restoring cell-level metadata
-      idents <- setNames(obs_df$active_ident, rownames(obs_df))
-      obs_df$active_ident <- NULL
+      idents <- obs_df$active_ident
+      if (!is.null(idents)) {
+        idents <- setNames(idents, rownames(obs_df))
+        obs_df$active_ident <- NULL
+      }
 
       object <- SeuratObject::CreateSeuratObject(
         counts = assays[[1]],

--- a/tests/testthat/test_SCDataset_Seurat.R
+++ b/tests/testthat/test_SCDataset_Seurat.R
@@ -102,3 +102,19 @@ test_that("a dataset containing an assay with empty cells is fully retrieved", {
   # Cannot add a different number of cells than already present
   expect_silent(scdataset$to_seurat())
 })
+
+test_that("a dataset with empty cell identities is retrieved", {
+  uri <- withr::local_tempdir("empty-cell-identities")
+  assay_counts <- SeuratObject::CreateSeuratObject(
+    counts = GetAssayData(pbmc_small[["RNA"]])
+  )
+
+  # verify identities is unset
+  testthat::expect_length(nlevels(SeuratObject::Idents(assay_counts)), 1L)
+
+  scdataset <- SCDataset$new(uri, verbose = FALSE)
+  scdataset$from_seurat(assay_counts)
+
+  # Should not trigger error
+  expect_silent(scdataset$to_seurat())
+})


### PR DESCRIPTION
Fix to avoid attempting to set name of `NULL` when a Seurat object's `active.idents` slot is empty. Also added a test for the ingestion/retrieval of a Seurat object without cell identities.
