### PR TITLE
Finding from CXG RDS ingest

### DIFF
--- a/R/SOMA.R
+++ b/R/SOMA.R
@@ -382,7 +382,12 @@ SOMA <- R6::R6Class(
       }
 
       assay_key <- SeuratObject::Key(object)
-      self$X$add_metadata(list(key = assay_key))
+      if (identical(assay_key, character(0))) {
+        message("Null assay_key; no metadata found")
+      } else {
+        self$X$add_metadata(list(key = assay_key))
+      }
+
       if (self$verbose) {
         msg <- sprintf(
           "Finished converting Seurat Assay with key [%s] to %s",

--- a/R/SOMA.R
+++ b/R/SOMA.R
@@ -381,10 +381,9 @@ SOMA <- R6::R6Class(
         )
       }
 
+      # Store value of the Assay object's key as metadata
       assay_key <- SeuratObject::Key(object)
-      if (identical(assay_key, character(0))) {
-        message("Null assay_key; no metadata found")
-      } else {
+      if (!is_empty(assay_key)) {
         self$X$add_metadata(list(key = assay_key))
       }
 
@@ -474,7 +473,10 @@ SOMA <- R6::R6Class(
       }
 
       # set metadata
-      SeuratObject::Key(assay_obj) <- self$X$get_metadata(key = "key")
+      assay_key <- self$X$get_metadata(key = "key")
+      if (!is.null(assay_key)) {
+        SeuratObject::Key(assay_obj) <- self$X$get_metadata(key = "key")
+      }
       return(assay_obj)
     },
 

--- a/R/SOMA.R
+++ b/R/SOMA.R
@@ -291,6 +291,11 @@ SOMA <- R6::R6Class(
     #' `highly_variable` attribute in `var` that records `1` or `0` for each
     #' feature indicating whether it was a variable feature or not.
     #'
+    #' ## Metadata
+    #'
+    #' * `key` (optional): Contains value of the the Seurat `Assay`'s `key` slot
+    #'   if it is set.
+    #'
     #' @param object A [`SeuratObject::Assay`] object
     #' @param var Should the `Assay`'s' feature-level annotations be ingested
     #' into the `var` array? If `FALSE` and the `var` array does not yet exist

--- a/tests/testthat/test_SCGroup_Seurat_Deprecated.R
+++ b/tests/testthat/test_SCGroup_Seurat_Deprecated.R
@@ -138,7 +138,6 @@ test_that("obs and var are created when even no annotations are present", {
     counts = SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
   )
   expect_equal(ncol(assay[[]]), 0L)
-  SeuratObject::Key(assay) <- "RNA"
 
   expect_warning(
     scgroup <- SCGroup$new(uri = uri),
@@ -307,7 +306,6 @@ test_that("an assay with empty feature metdata can be converted", {
   assay <- SeuratObject::CreateAssayObject(
     counts = SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
   )
-  SeuratObject::Key(assay) <- "RNA"
   expect_length(assay[[]], 0L)
 
   expect_warning(
@@ -325,7 +323,6 @@ test_that("individual layers can be added or updated", {
   assay <- SeuratObject::CreateAssayObject(
     counts = SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
   )
-  SeuratObject::Key(assay) <- "RNA"
 
   expect_warning(
     scgroup <- SCGroup$new(uri = uri, verbose = FALSE),

--- a/tests/testthat/test_SOMA_Seurat.R
+++ b/tests/testthat/test_SOMA_Seurat.R
@@ -121,7 +121,6 @@ test_that("obs and var are created when even no annotations are present", {
     counts = SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
   )
   expect_equal(ncol(assay[[]]), 0L)
-  SeuratObject::Key(assay) <- "RNA"
 
   soma <- SOMA$new(uri = uri)
   soma$from_seurat_assay(assay)
@@ -272,7 +271,6 @@ test_that("an assay with empty feature metdata can be converted", {
   assay <- SeuratObject::CreateAssayObject(
     counts = SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
   )
-  SeuratObject::Key(assay) <- "RNA"
   expect_length(assay[[]], 0L)
 
   soma <- SOMA$new(uri, verbose = FALSE)
@@ -287,7 +285,6 @@ test_that("individual layers can be added or updated", {
   assay <- SeuratObject::CreateAssayObject(
     counts = SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
   )
-  SeuratObject::Key(assay) <- "RNA"
 
   soma <- SOMA$new(uri, verbose = TRUE)
   soma$from_seurat_assay(assay)


### PR DESCRIPTION
In order to compare R <-> Python, in particular, their reading one another's data, and found the following -- I'm not sure the codemod currently on this PR is the right thing to do.

* Visit [https://cellxgene.cziscience.com/](https://cellxgene.cziscience.com/)
* Select a dataset and download a `.rds` file
* In R:
  * `library(tiledbsc)`
  * `rds = readRDS('adipocytes-seurat.rds')`
  * `soco = SOMACollection$new('foo')`
  * `soco$from_seurat(rds)`

```
Error in libtiledb_group_put_metadata(grp@ptr, key, val) :
  CHAR() can only be applied to a 'CHARSXP', not a 'NULL'
```

Works:

```
> data("pbmc_small", package = "SeuratObject")
> soco = SOMACollection$new('bar')
> soco$from_seurat(pbmc_small)

> SeuratObject::Assays(pbmc_small)
[1] "RNA"
> assay_object <- pbmc_small[["RNA"]]
> SeuratObject::Key(assay_object)
[1] "rna_" <-------------------------------------- difference
```

Issue here:

```
> rds = readRDS('adipocytes-seurat.rds')
> soco = SOMACollection$new('foo')

> SeuratObject::Assays(rds)
[1] "RNA"
> assay_object <- rds[["RNA"]]
> SeuratObject::Key(assay_object)
character(0)  <-------------------------------------- difference
```

Changes:

- storage and retrieval of a Seurat `Assay` key slot to/from metadata is now optional. If it's present, we'll store it, if it's not we don't. This is also now documented in `SOMA$from_seurat_assay()`.