### PR TITLE
Add internal object reference to TileDBArray class

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.2.9002
+Version: 0.1.2.9003
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",
@@ -42,7 +42,7 @@ Imports:
     fs,
     urltools
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Suggests:
     rmarkdown,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
 # tiledbsc (development version)
 
+## Migration to SOMA-based names
+
 This release changes the names of the 2 top-level classes in the tiledbsc package to follow new nomenclature adopted by the [single-cell data model specification](https://github.com/single-cell-data/matrix-api/blob/main/specification.md), which was implemented [here](https://github.com/single-cell-data/matrix-api/pull/28). You can read more about the rationale for this change [here](https://github.com/single-cell-data/matrix-api/issues/11#issuecomment-1109975498).
 
 Additionally, the `misc` slot has been renamed to `uns`. See below for details.
 
-## New class names
+New class names
 
 - `SCGroup` is replaced by `SOMA` (stack of matrices, annotated)
 - `SCDataset` is replaced by `SOMACollection`
@@ -28,6 +30,8 @@ For backwards compatibility:
 
 - Added `TileDBObject` base class to provide fields and methods common to both `TileDBArray`- and `TileDBGroup`-based classes
 - The `array_exists()` and `group_exists()` methods have been deprecated in favor of the more general `exists()`
+- Similar to the `TileDBGroup` class, `TileDBArray` now maintains a reference to the underlying array pointer
+- All classes gain a `objects` field to access the underlying TileDB objects directly
 
 # tiledbsc 0.1.2
 

--- a/R/AnnotationArray.R
+++ b/R/AnnotationArray.R
@@ -53,9 +53,10 @@ AnnotationArray <- R6::R6Class(
     # @param x A [`data.frame`]
     ingest_data = function(x) {
       private$log_array_ingestion()
-      tdb_array <- tiledb::tiledb_array(self$uri, query_type = "WRITE")
-      tdb_array[] <- x
-      tiledb::tiledb_array_close(tdb_array)
+      on.exit(private$close())
+      private$open("WRITE")
+      arr <- self$object
+      arr[] <- x
     },
 
     log_array_creation = function(index_cols) {

--- a/R/AnnotationDataframe.R
+++ b/R/AnnotationDataframe.R
@@ -56,10 +56,12 @@ AnnotationDataframe <- R6::R6Class(
           sprintf("Reading %s into memory from '%s'", self$class(), self$uri)
         )
       }
-      attrs <- attrs %||% character()
-      df <- self$tiledb_array(attrs = attrs, return_as = "data.frame")[]
-      dimname <- self$dimnames()
+      arr <- self$object
+      tiledb::attrs(arr) <- attrs %||% character()
+      tiledb::return_as(arr) <- "data.frame"
+      df <- arr[]
 
+      dimname <- self$dimnames()
       data.frame(
         df[setdiff(colnames(df), dimname)],
         row.names = df[[dimname]]

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -160,7 +160,8 @@ TileDBArray <- R6::R6Class(
     initialize_object = function() {
       private$object <- tiledb::tiledb_array(
         uri = self$uri,
-        ctx = self$ctx
+        ctx = self$ctx,
+        query_layout = "UNORDERED"
       )
       private$close()
     },

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -70,18 +70,17 @@ TileDBArray <- R6::R6Class(
     #'   is not NULL.
     #' @return A list of metadata values.
     get_metadata = function(key = NULL, prefix = NULL) {
-      arr <- self$tiledb_array()
-      tiledb::tiledb_array_open(arr, "READ")
+      on.exit(private$close())
+      private$open("READ")
       if (!is.null(key)) {
-        metadata <- tiledb::tiledb_get_metadata(arr, key)
+        metadata <- tiledb::tiledb_get_metadata(self$object, key)
       } else {
         # coerce tiledb_metadata to list
-        metadata <- unclass(tiledb::tiledb_get_all_metadata(arr))
+        metadata <- unclass(tiledb::tiledb_get_all_metadata(self$object))
         if (!is.null(prefix)) {
           metadata <- metadata[string_starts_with(names(metadata), prefix)]
         }
       }
-      tiledb::tiledb_array_close(arr)
       return(metadata)
     },
 
@@ -93,23 +92,21 @@ TileDBArray <- R6::R6Class(
       stopifnot(
         "Metadata must be a named list" = is_named_list(metadata)
       )
-      arr <- self$tiledb_array()
-      tiledb::tiledb_array_open(arr, "WRITE")
+      on.exit(private$close())
+      private$open("WRITE")
       mapply(
         FUN = tiledb::tiledb_put_metadata,
         key = paste0(prefix, names(metadata)),
         val = metadata,
-        MoreArgs = list(arr = arr),
+        MoreArgs = list(arr = self$object),
         SIMPLIFY = FALSE
       )
-      tiledb::tiledb_array_close(arr)
-      return(NULL)
     },
 
     #' @description Retrieve the array schema
     #' @return A [`tiledb::tiledb_array_schema`] object
     schema = function() {
-      tiledb::schema(self$tiledb_array())
+      tiledb::schema(self$object)
     },
 
     #' @description Retrieve the array dimensions
@@ -156,9 +153,9 @@ TileDBArray <- R6::R6Class(
   private = list(
 
     # Once the array has been created this initializes the TileDB array object
-    # and stores the reference in private$object.
+    # and stores the reference in private$tiledb_object.
     initialize_object = function() {
-      private$object <- tiledb::tiledb_array(
+      private$tiledb_object <- tiledb::tiledb_array(
         uri = self$uri,
         ctx = self$ctx,
         query_layout = "UNORDERED"
@@ -171,11 +168,11 @@ TileDBArray <- R6::R6Class(
 
     open = function(mode) {
       mode <- match.arg(mode, c("READ", "WRITE"))
-      invisible(tiledb::tiledb_array_open(private$object, type = mode))
+      invisible(tiledb::tiledb_array_open(self$object, type = mode))
     },
 
     close = function() {
-      invisible(tiledb::tiledb_array_close(private$object))
+      invisible(tiledb::tiledb_array_close(self$object))
     },
 
     # @description Ingest data into the TileDB array.

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -25,6 +25,7 @@ TileDBArray <- R6::R6Class(
 
       if (self$exists()) {
         msg <- sprintf("Found existing %s at '%s'", self$class(), self$uri)
+        private$initialize_object()
       } else {
         msg <- sprintf("No %s found at '%s'", self$class(), self$uri)
       }
@@ -153,8 +154,28 @@ TileDBArray <- R6::R6Class(
   ),
 
   private = list(
+
+    # Once the array has been created this initializes the TileDB array object
+    # and stores the reference in private$object.
+    initialize_object = function() {
+      private$object <- tiledb::tiledb_array(
+        uri = self$uri,
+        ctx = self$ctx
+      )
+      private$close()
+    },
+
     # @description Create empty TileDB array.
     create_empty_array = function() return(NULL),
+
+    open = function(mode) {
+      mode <- match.arg(mode, c("READ", "WRITE"))
+      invisible(tiledb::tiledb_array_open(private$object, type = mode))
+    },
+
+    close = function() {
+      invisible(tiledb::tiledb_array_close(private$object))
+    },
 
     # @description Ingest data into the TileDB array.
     ingest_data = function() return(NULL)

--- a/R/TileDBGroup.R
+++ b/R/TileDBGroup.R
@@ -38,7 +38,7 @@ TileDBGroup <- R6::R6Class(
         private$create_group()
       }
 
-      private$group <- tiledb::tiledb_group(self$uri, ctx = self$ctx)
+      private$object <- tiledb::tiledb_group(self$uri, ctx = self$ctx)
       private$group_close()
 
       # Instatiate objects for existing members
@@ -132,7 +132,7 @@ TileDBGroup <- R6::R6Class(
       on.exit(private$group_close())
       private$group_open("WRITE")
       tiledb::tiledb_group_add_member(
-        grp = private$group,
+        grp = private$object,
         uri = uri,
         relative = relative,
         name = name
@@ -145,7 +145,7 @@ TileDBGroup <- R6::R6Class(
     count_members = function() {
       on.exit(private$group_close())
       private$group_open("READ")
-      tiledb::tiledb_group_member_count(private$group)
+      tiledb::tiledb_group_member_count(private$object)
     },
 
     #' @description List the members of the group.
@@ -166,7 +166,7 @@ TileDBGroup <- R6::R6Class(
       member_list <- lapply(
         X = seq_len(count) - 1L,
         FUN = tiledb::tiledb_group_member,
-        grp = private$group
+        grp = private$object
       )
 
       members$TYPE <- vapply_char(member_list, FUN = getElement, name = 1L)
@@ -235,9 +235,9 @@ TileDBGroup <- R6::R6Class(
       on.exit(private$group_close())
       private$group_open("READ")
       if (!is.null(key)) {
-        metadata <- tiledb::tiledb_group_get_metadata(private$group, key)
+        metadata <- tiledb::tiledb_group_get_metadata(private$object, key)
       } else {
-        metadata <- tiledb::tiledb_group_get_all_metadata(private$group)
+        metadata <- tiledb::tiledb_group_get_all_metadata(private$object)
         if (!is.null(prefix)) {
           metadata <- metadata[string_starts_with(names(metadata), prefix)]
         }
@@ -259,16 +259,13 @@ TileDBGroup <- R6::R6Class(
         FUN = tiledb::tiledb_group_put_metadata,
         key = paste0(prefix, names(metadata)),
         val = metadata,
-        MoreArgs = list(grp = private$group),
+        MoreArgs = list(grp = private$object),
         SIMPLIFY = FALSE
       )
     }
   ),
 
   private = list(
-
-    # Internal pointer to the TileDB group
-    group = NULL,
 
     create_group = function() {
       if (self$verbose) {
@@ -279,11 +276,11 @@ TileDBGroup <- R6::R6Class(
 
     group_open = function(mode) {
       mode <- match.arg(mode, c("READ", "WRITE"))
-      invisible(tiledb::tiledb_group_open(private$group, type = mode))
+      invisible(tiledb::tiledb_group_open(private$object, type = mode))
     },
 
     group_close = function() {
-      invisible(tiledb::tiledb_group_close(private$group))
+      invisible(tiledb::tiledb_group_close(private$object))
     },
 
     # Instantiate existing group members

--- a/R/TileDBGroup.R
+++ b/R/TileDBGroup.R
@@ -130,7 +130,7 @@ TileDBGroup <- R6::R6Class(
       on.exit(private$close())
       private$open("WRITE")
       tiledb::tiledb_group_add_member(
-        grp = private$object,
+        grp = self$object,
         uri = uri,
         relative = relative,
         name = name
@@ -143,7 +143,7 @@ TileDBGroup <- R6::R6Class(
     count_members = function() {
       on.exit(private$close())
       private$open("READ")
-      tiledb::tiledb_group_member_count(private$object)
+      tiledb::tiledb_group_member_count(self$object)
     },
 
     #' @description List the members of the group.
@@ -164,7 +164,7 @@ TileDBGroup <- R6::R6Class(
       member_list <- lapply(
         X = seq_len(count) - 1L,
         FUN = tiledb::tiledb_group_member,
-        grp = private$object
+        grp = self$object
       )
 
       members$TYPE <- vapply_char(member_list, FUN = getElement, name = 1L)
@@ -233,9 +233,9 @@ TileDBGroup <- R6::R6Class(
       on.exit(private$close())
       private$open("READ")
       if (!is.null(key)) {
-        metadata <- tiledb::tiledb_group_get_metadata(private$object, key)
+        metadata <- tiledb::tiledb_group_get_metadata(self$object, key)
       } else {
-        metadata <- tiledb::tiledb_group_get_all_metadata(private$object)
+        metadata <- tiledb::tiledb_group_get_all_metadata(self$object)
         if (!is.null(prefix)) {
           metadata <- metadata[string_starts_with(names(metadata), prefix)]
         }
@@ -257,7 +257,7 @@ TileDBGroup <- R6::R6Class(
         FUN = tiledb::tiledb_group_put_metadata,
         key = paste0(prefix, names(metadata)),
         val = metadata,
-        MoreArgs = list(grp = private$object),
+        MoreArgs = list(grp = self$object),
         SIMPLIFY = FALSE
       )
     }
@@ -274,15 +274,15 @@ TileDBGroup <- R6::R6Class(
 
     open = function(mode) {
       mode <- match.arg(mode, c("READ", "WRITE"))
-      invisible(tiledb::tiledb_group_open(private$object, type = mode))
+      invisible(tiledb::tiledb_group_open(self$object, type = mode))
     },
 
     close = function() {
-      invisible(tiledb::tiledb_group_close(private$object))
+      invisible(tiledb::tiledb_group_close(self$object))
     },
 
     initialize_object = function() {
-      private$object <- tiledb::tiledb_group(self$uri, ctx = self$ctx)
+      private$tiledb_object <- tiledb::tiledb_group(self$uri, ctx = self$ctx)
       private$close()
     },
 

--- a/R/TileDBObject.R
+++ b/R/TileDBObject.R
@@ -66,15 +66,6 @@ TileDBObject <- R6::R6Class(
         stop("Unknown object type")
       }
       tiledb::tiledb_object_type(uri, ctx = self$ctx) %in% expected_type
-    },
-
-    #' @description Retrieve the TileB object
-    #' @return A [`tiledb::tiledb_array`] or [`tiledb::tiledb_group`] object.
-    get_object = function() {
-      if (!self$exists()) {
-        stop("TileDB object does not exist")
-      }
-      private$object
     }
   ),
 
@@ -84,13 +75,31 @@ TileDBObject <- R6::R6Class(
     uri = function(value) {
       if (missing(value)) return(private$tiledb_uri$uri)
       stop(sprintf("'%s' is a read-only field.", "uri"))
+    },
+
+    #' @field object Access the underlying TileB object directly (either a
+    #' [`tiledb::tiledb_array`] or [`tiledb::tiledb_group`]).
+    object = function(value) {
+      if (!missing(value)) {
+        stop(sprintf("'%s' is a read-only field.", "object"))
+      }
+      # If the array was created after the object was instantiated, we need to
+      # initialize private$tiledb_object
+      if (is.null(private$tiledb_object)) {
+        if (self$exists()) {
+          private$initialize_object()
+        } else {
+          stop("TileDB object does not exist")
+        }
+      }
+      private$tiledb_object
     }
   ),
 
   private = list(
 
     # Internal pointer to the TileDB object
-    object = NULL,
+    tiledb_object = NULL,
 
     # @description Contains TileDBURI object
     tiledb_uri = NULL

--- a/R/TileDBObject.R
+++ b/R/TileDBObject.R
@@ -66,6 +66,15 @@ TileDBObject <- R6::R6Class(
         stop("Unknown object type")
       }
       tiledb::tiledb_object_type(uri, ctx = self$ctx) %in% expected_type
+    },
+
+    #' @description Retrieve the TileB object
+    #' @return A [`tiledb::tiledb_array`] or [`tiledb::tiledb_group`] object.
+    get_object = function() {
+      if (!self$exists()) {
+        stop("TileDB object does not exist")
+      }
+      private$object
     }
   ),
 

--- a/man/AnnotationArray.Rd
+++ b/man/AnnotationArray.Rd
@@ -14,32 +14,32 @@ Base class for Annotation Arrays
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-clone}{\code{AnnotationArray$clone()}}
+\item \href{#method-AnnotationArray-clone}{\code{AnnotationArray$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-add_metadata}{\code{tiledbsc::TileDBArray$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists">}\href{../../tiledbsc/html/TileDBArray.html#method-array_exists}{\code{tiledbsc::TileDBArray$array_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes">}\href{../../tiledbsc/html/TileDBArray.html#method-attributes}{\code{tiledbsc::TileDBArray$attributes()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames">}\href{../../tiledbsc/html/TileDBArray.html#method-attrnames}{\code{tiledbsc::TileDBArray$attrnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions">}\href{../../tiledbsc/html/TileDBArray.html#method-dimensions}{\code{tiledbsc::TileDBArray$dimensions()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames">}\href{../../tiledbsc/html/TileDBArray.html#method-dimnames}{\code{tiledbsc::TileDBArray$dimnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count">}\href{../../tiledbsc/html/TileDBArray.html#method-fragment_count}{\code{tiledbsc::TileDBArray$fragment_count()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-get_metadata}{\code{tiledbsc::TileDBArray$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize">}\href{../../tiledbsc/html/TileDBArray.html#method-initialize}{\code{tiledbsc::TileDBArray$initialize()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print">}\href{../../tiledbsc/html/TileDBArray.html#method-print}{\code{tiledbsc::TileDBArray$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema">}\href{../../tiledbsc/html/TileDBArray.html#method-schema}{\code{tiledbsc::TileDBArray$schema()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array">}\href{../../tiledbsc/html/TileDBArray.html#method-tiledb_array}{\code{tiledbsc::TileDBArray$tiledb_array()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-add_metadata'><code>tiledbsc::TileDBArray$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-array_exists'><code>tiledbsc::TileDBArray$array_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attributes'><code>tiledbsc::TileDBArray$attributes()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attrnames'><code>tiledbsc::TileDBArray$attrnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimensions'><code>tiledbsc::TileDBArray$dimensions()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimnames'><code>tiledbsc::TileDBArray$dimnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-fragment_count'><code>tiledbsc::TileDBArray$fragment_count()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-get_metadata'><code>tiledbsc::TileDBArray$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-initialize'><code>tiledbsc::TileDBArray$initialize()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsc::TileDBArray$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsc::TileDBArray$schema()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsc::TileDBArray$tiledb_array()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-AnnotationArray-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationArray-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/AnnotationDataframe.Rd
+++ b/man/AnnotationDataframe.Rd
@@ -26,34 +26,34 @@ annotations/measurements.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-from_dataframe}{\code{AnnotationDataframe$from_dataframe()}}
-\item \href{#method-to_dataframe}{\code{AnnotationDataframe$to_dataframe()}}
-\item \href{#method-clone}{\code{AnnotationDataframe$clone()}}
+\item \href{#method-AnnotationDataframe-from_dataframe}{\code{AnnotationDataframe$from_dataframe()}}
+\item \href{#method-AnnotationDataframe-to_dataframe}{\code{AnnotationDataframe$to_dataframe()}}
+\item \href{#method-AnnotationDataframe-clone}{\code{AnnotationDataframe$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-add_metadata}{\code{tiledbsc::TileDBArray$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists">}\href{../../tiledbsc/html/TileDBArray.html#method-array_exists}{\code{tiledbsc::TileDBArray$array_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes">}\href{../../tiledbsc/html/TileDBArray.html#method-attributes}{\code{tiledbsc::TileDBArray$attributes()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames">}\href{../../tiledbsc/html/TileDBArray.html#method-attrnames}{\code{tiledbsc::TileDBArray$attrnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions">}\href{../../tiledbsc/html/TileDBArray.html#method-dimensions}{\code{tiledbsc::TileDBArray$dimensions()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames">}\href{../../tiledbsc/html/TileDBArray.html#method-dimnames}{\code{tiledbsc::TileDBArray$dimnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count">}\href{../../tiledbsc/html/TileDBArray.html#method-fragment_count}{\code{tiledbsc::TileDBArray$fragment_count()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-get_metadata}{\code{tiledbsc::TileDBArray$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize">}\href{../../tiledbsc/html/TileDBArray.html#method-initialize}{\code{tiledbsc::TileDBArray$initialize()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print">}\href{../../tiledbsc/html/TileDBArray.html#method-print}{\code{tiledbsc::TileDBArray$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema">}\href{../../tiledbsc/html/TileDBArray.html#method-schema}{\code{tiledbsc::TileDBArray$schema()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array">}\href{../../tiledbsc/html/TileDBArray.html#method-tiledb_array}{\code{tiledbsc::TileDBArray$tiledb_array()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-add_metadata'><code>tiledbsc::TileDBArray$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-array_exists'><code>tiledbsc::TileDBArray$array_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attributes'><code>tiledbsc::TileDBArray$attributes()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attrnames'><code>tiledbsc::TileDBArray$attrnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimensions'><code>tiledbsc::TileDBArray$dimensions()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimnames'><code>tiledbsc::TileDBArray$dimnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-fragment_count'><code>tiledbsc::TileDBArray$fragment_count()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-get_metadata'><code>tiledbsc::TileDBArray$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-initialize'><code>tiledbsc::TileDBArray$initialize()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsc::TileDBArray$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsc::TileDBArray$schema()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsc::TileDBArray$tiledb_array()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-from_dataframe"></a>}}
-\if{latex}{\out{\hypertarget{method-from_dataframe}{}}}
+\if{html}{\out{<a id="method-AnnotationDataframe-from_dataframe"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationDataframe-from_dataframe}{}}}
 \subsection{Method \code{from_dataframe()}}{
 Ingest annotation data
 \subsection{Usage}{
@@ -72,8 +72,8 @@ contain the data.frame row names.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_dataframe"></a>}}
-\if{latex}{\out{\hypertarget{method-to_dataframe}{}}}
+\if{html}{\out{<a id="method-AnnotationDataframe-to_dataframe"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationDataframe-to_dataframe}{}}}
 \subsection{Method \code{to_dataframe()}}{
 Retrieve the annotation data from TileDB
 \subsection{Usage}{
@@ -94,8 +94,8 @@ dimension
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-AnnotationDataframe-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationDataframe-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/AnnotationGroup.Rd
+++ b/man/AnnotationGroup.Rd
@@ -22,34 +22,34 @@ arrays within the group (typically \code{obs_id} or \code{var_id}).}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{AnnotationGroup$new()}}
-\item \href{#method-clone}{\code{AnnotationGroup$clone()}}
+\item \href{#method-AnnotationGroup-new}{\code{AnnotationGroup$new()}}
+\item \href{#method-AnnotationGroup-clone}{\code{AnnotationGroup$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_member}{\code{tiledbsc::TileDBGroup$add_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_metadata}{\code{tiledbsc::TileDBGroup$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-count_members}{\code{tiledbsc::TileDBGroup$count_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_member}{\code{tiledbsc::TileDBGroup$get_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_members}{\code{tiledbsc::TileDBGroup$get_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_metadata}{\code{tiledbsc::TileDBGroup$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists">}\href{../../tiledbsc/html/TileDBGroup.html#method-group_exists}{\code{tiledbsc::TileDBGroup$group_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_member_uris}{\code{tiledbsc::TileDBGroup$list_member_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_members}{\code{tiledbsc::TileDBGroup$list_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_object_uris}{\code{tiledbsc::TileDBGroup$list_object_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_objects}{\code{tiledbsc::TileDBGroup$list_objects()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print">}\href{../../tiledbsc/html/TileDBGroup.html#method-print}{\code{tiledbsc::TileDBGroup$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group">}\href{../../tiledbsc/html/TileDBGroup.html#method-tiledb_group}{\code{tiledbsc::TileDBGroup$tiledb_group()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_member'><code>tiledbsc::TileDBGroup$add_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_metadata'><code>tiledbsc::TileDBGroup$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-count_members'><code>tiledbsc::TileDBGroup$count_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_member'><code>tiledbsc::TileDBGroup$get_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_members'><code>tiledbsc::TileDBGroup$get_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_metadata'><code>tiledbsc::TileDBGroup$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-group_exists'><code>tiledbsc::TileDBGroup$group_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_member_uris'><code>tiledbsc::TileDBGroup$list_member_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_members'><code>tiledbsc::TileDBGroup$list_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_object_uris'><code>tiledbsc::TileDBGroup$list_object_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_objects'><code>tiledbsc::TileDBGroup$list_objects()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-print'><code>tiledbsc::TileDBGroup$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-tiledb_group'><code>tiledbsc::TileDBGroup$tiledb_group()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-AnnotationGroup-new"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationGroup-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new \code{TileDBGroup}-based Annotation class.
 \subsection{Usage}{
@@ -70,8 +70,8 @@ arrays.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-AnnotationGroup-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationGroup-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/AnnotationMatrix.Rd
+++ b/man/AnnotationMatrix.Rd
@@ -25,34 +25,34 @@ features of a \code{\link{SOMA}}.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-from_matrix}{\code{AnnotationMatrix$from_matrix()}}
-\item \href{#method-to_matrix}{\code{AnnotationMatrix$to_matrix()}}
-\item \href{#method-clone}{\code{AnnotationMatrix$clone()}}
+\item \href{#method-AnnotationMatrix-from_matrix}{\code{AnnotationMatrix$from_matrix()}}
+\item \href{#method-AnnotationMatrix-to_matrix}{\code{AnnotationMatrix$to_matrix()}}
+\item \href{#method-AnnotationMatrix-clone}{\code{AnnotationMatrix$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-add_metadata}{\code{tiledbsc::TileDBArray$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists">}\href{../../tiledbsc/html/TileDBArray.html#method-array_exists}{\code{tiledbsc::TileDBArray$array_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes">}\href{../../tiledbsc/html/TileDBArray.html#method-attributes}{\code{tiledbsc::TileDBArray$attributes()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames">}\href{../../tiledbsc/html/TileDBArray.html#method-attrnames}{\code{tiledbsc::TileDBArray$attrnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions">}\href{../../tiledbsc/html/TileDBArray.html#method-dimensions}{\code{tiledbsc::TileDBArray$dimensions()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames">}\href{../../tiledbsc/html/TileDBArray.html#method-dimnames}{\code{tiledbsc::TileDBArray$dimnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count">}\href{../../tiledbsc/html/TileDBArray.html#method-fragment_count}{\code{tiledbsc::TileDBArray$fragment_count()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-get_metadata}{\code{tiledbsc::TileDBArray$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize">}\href{../../tiledbsc/html/TileDBArray.html#method-initialize}{\code{tiledbsc::TileDBArray$initialize()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print">}\href{../../tiledbsc/html/TileDBArray.html#method-print}{\code{tiledbsc::TileDBArray$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema">}\href{../../tiledbsc/html/TileDBArray.html#method-schema}{\code{tiledbsc::TileDBArray$schema()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array">}\href{../../tiledbsc/html/TileDBArray.html#method-tiledb_array}{\code{tiledbsc::TileDBArray$tiledb_array()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-add_metadata'><code>tiledbsc::TileDBArray$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-array_exists'><code>tiledbsc::TileDBArray$array_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attributes'><code>tiledbsc::TileDBArray$attributes()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attrnames'><code>tiledbsc::TileDBArray$attrnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimensions'><code>tiledbsc::TileDBArray$dimensions()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimnames'><code>tiledbsc::TileDBArray$dimnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-fragment_count'><code>tiledbsc::TileDBArray$fragment_count()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-get_metadata'><code>tiledbsc::TileDBArray$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-initialize'><code>tiledbsc::TileDBArray$initialize()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsc::TileDBArray$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsc::TileDBArray$schema()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsc::TileDBArray$tiledb_array()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-from_matrix"></a>}}
-\if{latex}{\out{\hypertarget{method-from_matrix}{}}}
+\if{html}{\out{<a id="method-AnnotationMatrix-from_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationMatrix-from_matrix}{}}}
 \subsection{Method \code{from_matrix()}}{
 Ingest annotation matrix
 \subsection{Usage}{
@@ -71,8 +71,8 @@ contain the matrix row names.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_matrix"></a>}}
-\if{latex}{\out{\hypertarget{method-to_matrix}{}}}
+\if{html}{\out{<a id="method-AnnotationMatrix-to_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationMatrix-to_matrix}{}}}
 \subsection{Method \code{to_matrix()}}{
 Retrieve the annotation data from TileDB
 \subsection{Usage}{
@@ -84,8 +84,8 @@ A \code{\link{matrix}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-AnnotationMatrix-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationMatrix-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/AnnotationMatrixGroup.Rd
+++ b/man/AnnotationMatrixGroup.Rd
@@ -13,35 +13,35 @@ Class for representing a TileDB group containing one or more
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-add_annotation_matrix}{\code{AnnotationMatrixGroup$add_annotation_matrix()}}
-\item \href{#method-clone}{\code{AnnotationMatrixGroup$clone()}}
+\item \href{#method-AnnotationMatrixGroup-add_annotation_matrix}{\code{AnnotationMatrixGroup$add_annotation_matrix()}}
+\item \href{#method-AnnotationMatrixGroup-clone}{\code{AnnotationMatrixGroup$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_member}{\code{tiledbsc::TileDBGroup$add_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_metadata}{\code{tiledbsc::TileDBGroup$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-count_members}{\code{tiledbsc::TileDBGroup$count_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_member}{\code{tiledbsc::TileDBGroup$get_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_members}{\code{tiledbsc::TileDBGroup$get_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_metadata}{\code{tiledbsc::TileDBGroup$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists">}\href{../../tiledbsc/html/TileDBGroup.html#method-group_exists}{\code{tiledbsc::TileDBGroup$group_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_member_uris}{\code{tiledbsc::TileDBGroup$list_member_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_members}{\code{tiledbsc::TileDBGroup$list_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_object_uris}{\code{tiledbsc::TileDBGroup$list_object_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_objects}{\code{tiledbsc::TileDBGroup$list_objects()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print">}\href{../../tiledbsc/html/TileDBGroup.html#method-print}{\code{tiledbsc::TileDBGroup$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group">}\href{../../tiledbsc/html/TileDBGroup.html#method-tiledb_group}{\code{tiledbsc::TileDBGroup$tiledb_group()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="AnnotationGroup" data-id="initialize">}\href{../../tiledbsc/html/AnnotationGroup.html#method-initialize}{\code{tiledbsc::AnnotationGroup$initialize()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_member'><code>tiledbsc::TileDBGroup$add_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_metadata'><code>tiledbsc::TileDBGroup$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-count_members'><code>tiledbsc::TileDBGroup$count_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_member'><code>tiledbsc::TileDBGroup$get_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_members'><code>tiledbsc::TileDBGroup$get_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_metadata'><code>tiledbsc::TileDBGroup$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-group_exists'><code>tiledbsc::TileDBGroup$group_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_member_uris'><code>tiledbsc::TileDBGroup$list_member_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_members'><code>tiledbsc::TileDBGroup$list_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_object_uris'><code>tiledbsc::TileDBGroup$list_object_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_objects'><code>tiledbsc::TileDBGroup$list_objects()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-print'><code>tiledbsc::TileDBGroup$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-tiledb_group'><code>tiledbsc::TileDBGroup$tiledb_group()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="AnnotationGroup" data-id="initialize"><a href='../../tiledbsc/html/AnnotationGroup.html#method-AnnotationGroup-initialize'><code>tiledbsc::AnnotationGroup$initialize()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-add_annotation_matrix"></a>}}
-\if{latex}{\out{\hypertarget{method-add_annotation_matrix}{}}}
+\if{html}{\out{<a id="method-AnnotationMatrixGroup-add_annotation_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationMatrixGroup-add_annotation_matrix}{}}}
 \subsection{Method \code{add_annotation_matrix()}}{
 Add a new \code{\link{AnnotationMatrix}} array to the group.
 \subsection{Usage}{
@@ -63,8 +63,8 @@ must be aligned to the \code{\link{SOMA}} dimension indicated by the group's
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-AnnotationMatrixGroup-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationMatrixGroup-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/AnnotationPairwiseMatrix.Rd
+++ b/man/AnnotationPairwiseMatrix.Rd
@@ -19,37 +19,37 @@ columns aligned to either the observations or features of \code{X}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-from_matrix}{\code{AnnotationPairwiseMatrix$from_matrix()}}
-\item \href{#method-to_matrix}{\code{AnnotationPairwiseMatrix$to_matrix()}}
-\item \href{#method-to_dataframe}{\code{AnnotationPairwiseMatrix$to_dataframe()}}
-\item \href{#method-to_sparse_matrix}{\code{AnnotationPairwiseMatrix$to_sparse_matrix()}}
-\item \href{#method-to_seurat_graph}{\code{AnnotationPairwiseMatrix$to_seurat_graph()}}
-\item \href{#method-clone}{\code{AnnotationPairwiseMatrix$clone()}}
+\item \href{#method-AnnotationPairwiseMatrix-from_matrix}{\code{AnnotationPairwiseMatrix$from_matrix()}}
+\item \href{#method-AnnotationPairwiseMatrix-to_matrix}{\code{AnnotationPairwiseMatrix$to_matrix()}}
+\item \href{#method-AnnotationPairwiseMatrix-to_dataframe}{\code{AnnotationPairwiseMatrix$to_dataframe()}}
+\item \href{#method-AnnotationPairwiseMatrix-to_sparse_matrix}{\code{AnnotationPairwiseMatrix$to_sparse_matrix()}}
+\item \href{#method-AnnotationPairwiseMatrix-to_seurat_graph}{\code{AnnotationPairwiseMatrix$to_seurat_graph()}}
+\item \href{#method-AnnotationPairwiseMatrix-clone}{\code{AnnotationPairwiseMatrix$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-add_metadata}{\code{tiledbsc::TileDBArray$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists">}\href{../../tiledbsc/html/TileDBArray.html#method-array_exists}{\code{tiledbsc::TileDBArray$array_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes">}\href{../../tiledbsc/html/TileDBArray.html#method-attributes}{\code{tiledbsc::TileDBArray$attributes()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames">}\href{../../tiledbsc/html/TileDBArray.html#method-attrnames}{\code{tiledbsc::TileDBArray$attrnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions">}\href{../../tiledbsc/html/TileDBArray.html#method-dimensions}{\code{tiledbsc::TileDBArray$dimensions()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames">}\href{../../tiledbsc/html/TileDBArray.html#method-dimnames}{\code{tiledbsc::TileDBArray$dimnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count">}\href{../../tiledbsc/html/TileDBArray.html#method-fragment_count}{\code{tiledbsc::TileDBArray$fragment_count()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-get_metadata}{\code{tiledbsc::TileDBArray$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize">}\href{../../tiledbsc/html/TileDBArray.html#method-initialize}{\code{tiledbsc::TileDBArray$initialize()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print">}\href{../../tiledbsc/html/TileDBArray.html#method-print}{\code{tiledbsc::TileDBArray$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema">}\href{../../tiledbsc/html/TileDBArray.html#method-schema}{\code{tiledbsc::TileDBArray$schema()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array">}\href{../../tiledbsc/html/TileDBArray.html#method-tiledb_array}{\code{tiledbsc::TileDBArray$tiledb_array()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-add_metadata'><code>tiledbsc::TileDBArray$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-array_exists'><code>tiledbsc::TileDBArray$array_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attributes'><code>tiledbsc::TileDBArray$attributes()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attrnames'><code>tiledbsc::TileDBArray$attrnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimensions'><code>tiledbsc::TileDBArray$dimensions()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimnames'><code>tiledbsc::TileDBArray$dimnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-fragment_count'><code>tiledbsc::TileDBArray$fragment_count()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-get_metadata'><code>tiledbsc::TileDBArray$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-initialize'><code>tiledbsc::TileDBArray$initialize()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsc::TileDBArray$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsc::TileDBArray$schema()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsc::TileDBArray$tiledb_array()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-from_matrix"></a>}}
-\if{latex}{\out{\hypertarget{method-from_matrix}{}}}
+\if{html}{\out{<a id="method-AnnotationPairwiseMatrix-from_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationPairwiseMatrix-from_matrix}{}}}
 \subsection{Method \code{from_matrix()}}{
 Ingest annotation matrix
 \subsection{Usage}{
@@ -71,8 +71,8 @@ contain the matrix values.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_matrix"></a>}}
-\if{latex}{\out{\hypertarget{method-to_matrix}{}}}
+\if{html}{\out{<a id="method-AnnotationPairwiseMatrix-to_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationPairwiseMatrix-to_matrix}{}}}
 \subsection{Method \code{to_matrix()}}{
 Read annotation data from TileDB into a matrix
 \subsection{Usage}{
@@ -84,8 +84,8 @@ A \code{\link{matrix}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_dataframe"></a>}}
-\if{latex}{\out{\hypertarget{method-to_dataframe}{}}}
+\if{html}{\out{<a id="method-AnnotationPairwiseMatrix-to_dataframe"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationPairwiseMatrix-to_dataframe}{}}}
 \subsection{Method \code{to_dataframe()}}{
 Read annotation data from TileDB into a data frame
 \subsection{Usage}{
@@ -105,8 +105,8 @@ A \code{\link{data.frame}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_sparse_matrix"></a>}}
-\if{latex}{\out{\hypertarget{method-to_sparse_matrix}{}}}
+\if{html}{\out{<a id="method-AnnotationPairwiseMatrix-to_sparse_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationPairwiseMatrix-to_sparse_matrix}{}}}
 \subsection{Method \code{to_sparse_matrix()}}{
 Read annotation data from TileDB into a sparse matrix
 \subsection{Usage}{
@@ -118,8 +118,8 @@ A \code{\link[Matrix:dgTMatrix-class]{Matrix::dgTMatrix}}.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_seurat_graph"></a>}}
-\if{latex}{\out{\hypertarget{method-to_seurat_graph}{}}}
+\if{html}{\out{<a id="method-AnnotationPairwiseMatrix-to_seurat_graph"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationPairwiseMatrix-to_seurat_graph}{}}}
 \subsection{Method \code{to_seurat_graph()}}{
 Read annotation data from TileDB into Seurat Graph
 \subsection{Usage}{
@@ -131,8 +131,8 @@ A \code{\link[SeuratObject:Graph-class]{SeuratObject::Graph}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-AnnotationPairwiseMatrix-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationPairwiseMatrix-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/AnnotationPairwiseMatrixGroup.Rd
+++ b/man/AnnotationPairwiseMatrixGroup.Rd
@@ -13,36 +13,36 @@ Class for representing a TileDB group containing one or more
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-add_matrix}{\code{AnnotationPairwiseMatrixGroup$add_matrix()}}
-\item \href{#method-add_seurat_graph}{\code{AnnotationPairwiseMatrixGroup$add_seurat_graph()}}
-\item \href{#method-clone}{\code{AnnotationPairwiseMatrixGroup$clone()}}
+\item \href{#method-AnnotationPairwiseMatrixGroup-add_matrix}{\code{AnnotationPairwiseMatrixGroup$add_matrix()}}
+\item \href{#method-AnnotationPairwiseMatrixGroup-add_seurat_graph}{\code{AnnotationPairwiseMatrixGroup$add_seurat_graph()}}
+\item \href{#method-AnnotationPairwiseMatrixGroup-clone}{\code{AnnotationPairwiseMatrixGroup$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_member}{\code{tiledbsc::TileDBGroup$add_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_metadata}{\code{tiledbsc::TileDBGroup$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-count_members}{\code{tiledbsc::TileDBGroup$count_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_member}{\code{tiledbsc::TileDBGroup$get_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_members}{\code{tiledbsc::TileDBGroup$get_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_metadata}{\code{tiledbsc::TileDBGroup$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists">}\href{../../tiledbsc/html/TileDBGroup.html#method-group_exists}{\code{tiledbsc::TileDBGroup$group_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_member_uris}{\code{tiledbsc::TileDBGroup$list_member_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_members}{\code{tiledbsc::TileDBGroup$list_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_object_uris}{\code{tiledbsc::TileDBGroup$list_object_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_objects}{\code{tiledbsc::TileDBGroup$list_objects()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print">}\href{../../tiledbsc/html/TileDBGroup.html#method-print}{\code{tiledbsc::TileDBGroup$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group">}\href{../../tiledbsc/html/TileDBGroup.html#method-tiledb_group}{\code{tiledbsc::TileDBGroup$tiledb_group()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="AnnotationGroup" data-id="initialize">}\href{../../tiledbsc/html/AnnotationGroup.html#method-initialize}{\code{tiledbsc::AnnotationGroup$initialize()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_member'><code>tiledbsc::TileDBGroup$add_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_metadata'><code>tiledbsc::TileDBGroup$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-count_members'><code>tiledbsc::TileDBGroup$count_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_member'><code>tiledbsc::TileDBGroup$get_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_members'><code>tiledbsc::TileDBGroup$get_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_metadata'><code>tiledbsc::TileDBGroup$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-group_exists'><code>tiledbsc::TileDBGroup$group_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_member_uris'><code>tiledbsc::TileDBGroup$list_member_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_members'><code>tiledbsc::TileDBGroup$list_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_object_uris'><code>tiledbsc::TileDBGroup$list_object_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_objects'><code>tiledbsc::TileDBGroup$list_objects()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-print'><code>tiledbsc::TileDBGroup$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-tiledb_group'><code>tiledbsc::TileDBGroup$tiledb_group()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="AnnotationGroup" data-id="initialize"><a href='../../tiledbsc/html/AnnotationGroup.html#method-AnnotationGroup-initialize'><code>tiledbsc::AnnotationGroup$initialize()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-add_matrix"></a>}}
-\if{latex}{\out{\hypertarget{method-add_matrix}{}}}
+\if{html}{\out{<a id="method-AnnotationPairwiseMatrixGroup-add_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationPairwiseMatrixGroup-add_matrix}{}}}
 \subsection{Method \code{add_matrix()}}{
 Add a new \code{\link{AnnotationPairwiseMatrix}} array to the group.
 \subsection{Usage}{
@@ -64,8 +64,8 @@ must be aligned to the dimension indicated by the group's
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-add_seurat_graph"></a>}}
-\if{latex}{\out{\hypertarget{method-add_seurat_graph}{}}}
+\if{html}{\out{<a id="method-AnnotationPairwiseMatrixGroup-add_seurat_graph"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationPairwiseMatrixGroup-add_seurat_graph}{}}}
 \subsection{Method \code{add_seurat_graph()}}{
 Convert a \code{\link[SeuratObject:Graph-class]{SeuratObject::Graph}} object to
 \code{\link{AnnotationPairwiseMatrix}}.
@@ -100,8 +100,8 @@ used.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-AnnotationPairwiseMatrixGroup-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-AnnotationPairwiseMatrixGroup-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/AssayMatrix.Rd
+++ b/man/AssayMatrix.Rd
@@ -23,36 +23,36 @@ Used for the \code{X} field of \code{\link{SOMA}}.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-from_matrix}{\code{AssayMatrix$from_matrix()}}
-\item \href{#method-from_dataframe}{\code{AssayMatrix$from_dataframe()}}
-\item \href{#method-to_dataframe}{\code{AssayMatrix$to_dataframe()}}
-\item \href{#method-to_matrix}{\code{AssayMatrix$to_matrix()}}
-\item \href{#method-clone}{\code{AssayMatrix$clone()}}
+\item \href{#method-AssayMatrix-from_matrix}{\code{AssayMatrix$from_matrix()}}
+\item \href{#method-AssayMatrix-from_dataframe}{\code{AssayMatrix$from_dataframe()}}
+\item \href{#method-AssayMatrix-to_dataframe}{\code{AssayMatrix$to_dataframe()}}
+\item \href{#method-AssayMatrix-to_matrix}{\code{AssayMatrix$to_matrix()}}
+\item \href{#method-AssayMatrix-clone}{\code{AssayMatrix$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-add_metadata}{\code{tiledbsc::TileDBArray$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists">}\href{../../tiledbsc/html/TileDBArray.html#method-array_exists}{\code{tiledbsc::TileDBArray$array_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes">}\href{../../tiledbsc/html/TileDBArray.html#method-attributes}{\code{tiledbsc::TileDBArray$attributes()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames">}\href{../../tiledbsc/html/TileDBArray.html#method-attrnames}{\code{tiledbsc::TileDBArray$attrnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions">}\href{../../tiledbsc/html/TileDBArray.html#method-dimensions}{\code{tiledbsc::TileDBArray$dimensions()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames">}\href{../../tiledbsc/html/TileDBArray.html#method-dimnames}{\code{tiledbsc::TileDBArray$dimnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count">}\href{../../tiledbsc/html/TileDBArray.html#method-fragment_count}{\code{tiledbsc::TileDBArray$fragment_count()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-get_metadata}{\code{tiledbsc::TileDBArray$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize">}\href{../../tiledbsc/html/TileDBArray.html#method-initialize}{\code{tiledbsc::TileDBArray$initialize()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print">}\href{../../tiledbsc/html/TileDBArray.html#method-print}{\code{tiledbsc::TileDBArray$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema">}\href{../../tiledbsc/html/TileDBArray.html#method-schema}{\code{tiledbsc::TileDBArray$schema()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array">}\href{../../tiledbsc/html/TileDBArray.html#method-tiledb_array}{\code{tiledbsc::TileDBArray$tiledb_array()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-add_metadata'><code>tiledbsc::TileDBArray$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-array_exists'><code>tiledbsc::TileDBArray$array_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attributes'><code>tiledbsc::TileDBArray$attributes()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attrnames'><code>tiledbsc::TileDBArray$attrnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimensions'><code>tiledbsc::TileDBArray$dimensions()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimnames'><code>tiledbsc::TileDBArray$dimnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-fragment_count'><code>tiledbsc::TileDBArray$fragment_count()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-get_metadata'><code>tiledbsc::TileDBArray$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-initialize'><code>tiledbsc::TileDBArray$initialize()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsc::TileDBArray$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsc::TileDBArray$schema()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsc::TileDBArray$tiledb_array()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-from_matrix"></a>}}
-\if{latex}{\out{\hypertarget{method-from_matrix}{}}}
+\if{html}{\out{<a id="method-AssayMatrix-from_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-AssayMatrix-from_matrix}{}}}
 \subsection{Method \code{from_matrix()}}{
 Ingest assay data from a sparse matrix
 \subsection{Usage}{
@@ -75,8 +75,8 @@ contain the matrix values.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-from_dataframe"></a>}}
-\if{latex}{\out{\hypertarget{method-from_dataframe}{}}}
+\if{html}{\out{<a id="method-AssayMatrix-from_dataframe"></a>}}
+\if{latex}{\out{\hypertarget{method-AssayMatrix-from_dataframe}{}}}
 \subsection{Method \code{from_dataframe()}}{
 Ingest assay data from a COO-formatted data frame
 \subsection{Usage}{
@@ -96,8 +96,8 @@ other columns are ingested as attributes.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_dataframe"></a>}}
-\if{latex}{\out{\hypertarget{method-to_dataframe}{}}}
+\if{html}{\out{<a id="method-AssayMatrix-to_dataframe"></a>}}
+\if{latex}{\out{\hypertarget{method-AssayMatrix-to_dataframe}{}}}
 \subsection{Method \code{to_dataframe()}}{
 Retrieve the assay data from TileDB
 \subsection{Usage}{
@@ -117,8 +117,8 @@ A \code{\link[Matrix:dgTMatrix-class]{Matrix::dgTMatrix}}.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_matrix"></a>}}
-\if{latex}{\out{\hypertarget{method-to_matrix}{}}}
+\if{html}{\out{<a id="method-AssayMatrix-to_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-AssayMatrix-to_matrix}{}}}
 \subsection{Method \code{to_matrix()}}{
 Retrieve assay data from TileDB as a 2D sparse matrix.
 \subsection{Usage}{
@@ -138,8 +138,8 @@ A \code{\link[Matrix:dgTMatrix-class]{Matrix::dgTMatrix}}.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-AssayMatrix-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-AssayMatrix-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/AssayMatrixGroup.Rd
+++ b/man/AssayMatrixGroup.Rd
@@ -13,35 +13,35 @@ Class for representing a TileDB group containing one or more
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-add_assay_matrix}{\code{AssayMatrixGroup$add_assay_matrix()}}
-\item \href{#method-clone}{\code{AssayMatrixGroup$clone()}}
+\item \href{#method-AssayMatrixGroup-add_assay_matrix}{\code{AssayMatrixGroup$add_assay_matrix()}}
+\item \href{#method-AssayMatrixGroup-clone}{\code{AssayMatrixGroup$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_member}{\code{tiledbsc::TileDBGroup$add_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_metadata}{\code{tiledbsc::TileDBGroup$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-count_members}{\code{tiledbsc::TileDBGroup$count_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_member}{\code{tiledbsc::TileDBGroup$get_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_members}{\code{tiledbsc::TileDBGroup$get_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_metadata}{\code{tiledbsc::TileDBGroup$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists">}\href{../../tiledbsc/html/TileDBGroup.html#method-group_exists}{\code{tiledbsc::TileDBGroup$group_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_member_uris}{\code{tiledbsc::TileDBGroup$list_member_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_members}{\code{tiledbsc::TileDBGroup$list_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_object_uris}{\code{tiledbsc::TileDBGroup$list_object_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_objects}{\code{tiledbsc::TileDBGroup$list_objects()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print">}\href{../../tiledbsc/html/TileDBGroup.html#method-print}{\code{tiledbsc::TileDBGroup$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group">}\href{../../tiledbsc/html/TileDBGroup.html#method-tiledb_group}{\code{tiledbsc::TileDBGroup$tiledb_group()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="AnnotationGroup" data-id="initialize">}\href{../../tiledbsc/html/AnnotationGroup.html#method-initialize}{\code{tiledbsc::AnnotationGroup$initialize()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_member'><code>tiledbsc::TileDBGroup$add_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_metadata'><code>tiledbsc::TileDBGroup$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-count_members'><code>tiledbsc::TileDBGroup$count_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_member'><code>tiledbsc::TileDBGroup$get_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_members'><code>tiledbsc::TileDBGroup$get_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_metadata'><code>tiledbsc::TileDBGroup$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-group_exists'><code>tiledbsc::TileDBGroup$group_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_member_uris'><code>tiledbsc::TileDBGroup$list_member_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_members'><code>tiledbsc::TileDBGroup$list_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_object_uris'><code>tiledbsc::TileDBGroup$list_object_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_objects'><code>tiledbsc::TileDBGroup$list_objects()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-print'><code>tiledbsc::TileDBGroup$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-tiledb_group'><code>tiledbsc::TileDBGroup$tiledb_group()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="AnnotationGroup" data-id="initialize"><a href='../../tiledbsc/html/AnnotationGroup.html#method-AnnotationGroup-initialize'><code>tiledbsc::AnnotationGroup$initialize()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-add_assay_matrix"></a>}}
-\if{latex}{\out{\hypertarget{method-add_assay_matrix}{}}}
+\if{html}{\out{<a id="method-AssayMatrixGroup-add_assay_matrix"></a>}}
+\if{latex}{\out{\hypertarget{method-AssayMatrixGroup-add_assay_matrix}{}}}
 \subsection{Method \code{add_assay_matrix()}}{
 Add a new \code{\link{AssayMatrix}} array to the group.
 \subsection{Usage}{
@@ -71,8 +71,8 @@ contain the matrix values.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-AssayMatrixGroup-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-AssayMatrixGroup-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/CommandsArray.Rd
+++ b/man/CommandsArray.Rd
@@ -24,34 +24,34 @@ TileDB array with options for storing SeuratCommand objects.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-from_named_list_of_commands}{\code{CommandsArray$from_named_list_of_commands()}}
-\item \href{#method-to_named_list_of_commands}{\code{CommandsArray$to_named_list_of_commands()}}
-\item \href{#method-clone}{\code{CommandsArray$clone()}}
+\item \href{#method-CommandsArray-from_named_list_of_commands}{\code{CommandsArray$from_named_list_of_commands()}}
+\item \href{#method-CommandsArray-to_named_list_of_commands}{\code{CommandsArray$to_named_list_of_commands()}}
+\item \href{#method-CommandsArray-clone}{\code{CommandsArray$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-add_metadata}{\code{tiledbsc::TileDBArray$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists">}\href{../../tiledbsc/html/TileDBArray.html#method-array_exists}{\code{tiledbsc::TileDBArray$array_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes">}\href{../../tiledbsc/html/TileDBArray.html#method-attributes}{\code{tiledbsc::TileDBArray$attributes()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames">}\href{../../tiledbsc/html/TileDBArray.html#method-attrnames}{\code{tiledbsc::TileDBArray$attrnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions">}\href{../../tiledbsc/html/TileDBArray.html#method-dimensions}{\code{tiledbsc::TileDBArray$dimensions()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames">}\href{../../tiledbsc/html/TileDBArray.html#method-dimnames}{\code{tiledbsc::TileDBArray$dimnames()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count">}\href{../../tiledbsc/html/TileDBArray.html#method-fragment_count}{\code{tiledbsc::TileDBArray$fragment_count()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBArray.html#method-get_metadata}{\code{tiledbsc::TileDBArray$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize">}\href{../../tiledbsc/html/TileDBArray.html#method-initialize}{\code{tiledbsc::TileDBArray$initialize()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print">}\href{../../tiledbsc/html/TileDBArray.html#method-print}{\code{tiledbsc::TileDBArray$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema">}\href{../../tiledbsc/html/TileDBArray.html#method-schema}{\code{tiledbsc::TileDBArray$schema()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array">}\href{../../tiledbsc/html/TileDBArray.html#method-tiledb_array}{\code{tiledbsc::TileDBArray$tiledb_array()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-add_metadata'><code>tiledbsc::TileDBArray$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="array_exists"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-array_exists'><code>tiledbsc::TileDBArray$array_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attributes"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attributes'><code>tiledbsc::TileDBArray$attributes()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="attrnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-attrnames'><code>tiledbsc::TileDBArray$attrnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimensions"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimensions'><code>tiledbsc::TileDBArray$dimensions()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="dimnames"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-dimnames'><code>tiledbsc::TileDBArray$dimnames()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="fragment_count"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-fragment_count'><code>tiledbsc::TileDBArray$fragment_count()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-get_metadata'><code>tiledbsc::TileDBArray$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="initialize"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-initialize'><code>tiledbsc::TileDBArray$initialize()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="print"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-print'><code>tiledbsc::TileDBArray$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="schema"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-schema'><code>tiledbsc::TileDBArray$schema()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBArray" data-id="tiledb_array"><a href='../../tiledbsc/html/TileDBArray.html#method-TileDBArray-tiledb_array'><code>tiledbsc::TileDBArray$tiledb_array()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-from_named_list_of_commands"></a>}}
-\if{latex}{\out{\hypertarget{method-from_named_list_of_commands}{}}}
+\if{html}{\out{<a id="method-CommandsArray-from_named_list_of_commands"></a>}}
+\if{latex}{\out{\hypertarget{method-CommandsArray-from_named_list_of_commands}{}}}
 \subsection{Method \code{from_named_list_of_commands()}}{
 Store the Seurat Command history to TileDB
 \subsection{Usage}{
@@ -67,8 +67,8 @@ Store the Seurat Command history to TileDB
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_named_list_of_commands"></a>}}
-\if{latex}{\out{\hypertarget{method-to_named_list_of_commands}{}}}
+\if{html}{\out{<a id="method-CommandsArray-to_named_list_of_commands"></a>}}
+\if{latex}{\out{\hypertarget{method-CommandsArray-to_named_list_of_commands}{}}}
 \subsection{Method \code{to_named_list_of_commands()}}{
 Retrieve the Seurat Command history from TileDB
 \subsection{Usage}{
@@ -80,8 +80,8 @@ A named list of Seurat Command objects
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-CommandsArray-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-CommandsArray-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/SCDataset.Rd
+++ b/man/SCDataset.Rd
@@ -22,38 +22,38 @@ renamed to \code{\link{SOMACollection}}.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{SCDataset$new()}}
-\item \href{#method-scgroup_uris}{\code{SCDataset$scgroup_uris()}}
-\item \href{#method-clone}{\code{SCDataset$clone()}}
+\item \href{#method-SCDataset-new}{\code{SCDataset$new()}}
+\item \href{#method-SCDataset-scgroup_uris}{\code{SCDataset$scgroup_uris()}}
+\item \href{#method-SCDataset-clone}{\code{SCDataset$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_member}{\code{tiledbsc::TileDBGroup$add_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_metadata}{\code{tiledbsc::TileDBGroup$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-count_members}{\code{tiledbsc::TileDBGroup$count_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_member}{\code{tiledbsc::TileDBGroup$get_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_members}{\code{tiledbsc::TileDBGroup$get_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_metadata}{\code{tiledbsc::TileDBGroup$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists">}\href{../../tiledbsc/html/TileDBGroup.html#method-group_exists}{\code{tiledbsc::TileDBGroup$group_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_member_uris}{\code{tiledbsc::TileDBGroup$list_member_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_members}{\code{tiledbsc::TileDBGroup$list_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_object_uris}{\code{tiledbsc::TileDBGroup$list_object_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_objects}{\code{tiledbsc::TileDBGroup$list_objects()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print">}\href{../../tiledbsc/html/TileDBGroup.html#method-print}{\code{tiledbsc::TileDBGroup$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group">}\href{../../tiledbsc/html/TileDBGroup.html#method-tiledb_group}{\code{tiledbsc::TileDBGroup$tiledb_group()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMACollection" data-id="from_seurat">}\href{../../tiledbsc/html/SOMACollection.html#method-from_seurat}{\code{tiledbsc::SOMACollection$from_seurat()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMACollection" data-id="soma_uris">}\href{../../tiledbsc/html/SOMACollection.html#method-soma_uris}{\code{tiledbsc::SOMACollection$soma_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMACollection" data-id="to_seurat">}\href{../../tiledbsc/html/SOMACollection.html#method-to_seurat}{\code{tiledbsc::SOMACollection$to_seurat()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_member'><code>tiledbsc::TileDBGroup$add_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_metadata'><code>tiledbsc::TileDBGroup$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-count_members'><code>tiledbsc::TileDBGroup$count_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_member'><code>tiledbsc::TileDBGroup$get_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_members'><code>tiledbsc::TileDBGroup$get_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_metadata'><code>tiledbsc::TileDBGroup$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-group_exists'><code>tiledbsc::TileDBGroup$group_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_member_uris'><code>tiledbsc::TileDBGroup$list_member_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_members'><code>tiledbsc::TileDBGroup$list_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_object_uris'><code>tiledbsc::TileDBGroup$list_object_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_objects'><code>tiledbsc::TileDBGroup$list_objects()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-print'><code>tiledbsc::TileDBGroup$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-tiledb_group'><code>tiledbsc::TileDBGroup$tiledb_group()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMACollection" data-id="from_seurat"><a href='../../tiledbsc/html/SOMACollection.html#method-SOMACollection-from_seurat'><code>tiledbsc::SOMACollection$from_seurat()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMACollection" data-id="soma_uris"><a href='../../tiledbsc/html/SOMACollection.html#method-SOMACollection-soma_uris'><code>tiledbsc::SOMACollection$soma_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMACollection" data-id="to_seurat"><a href='../../tiledbsc/html/SOMACollection.html#method-SOMACollection-to_seurat'><code>tiledbsc::SOMACollection$to_seurat()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-SCDataset-new"></a>}}
+\if{latex}{\out{\hypertarget{method-SCDataset-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new SCDataset object.
 \subsection{Usage}{
@@ -75,8 +75,8 @@ Create a new SCDataset object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-scgroup_uris"></a>}}
-\if{latex}{\out{\hypertarget{method-scgroup_uris}{}}}
+\if{html}{\out{<a id="method-SCDataset-scgroup_uris"></a>}}
+\if{latex}{\out{\hypertarget{method-SCDataset-scgroup_uris}{}}}
 \subsection{Method \code{scgroup_uris()}}{
 List the \code{\link{SOMA}} (formerly \code{SCGroup}) URIs in the
 collection.
@@ -89,8 +89,8 @@ A vector of URIs for each \code{\link{SOMA}} in the collection.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-SCDataset-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-SCDataset-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/SCGroup.Rd
+++ b/man/SCGroup.Rd
@@ -20,44 +20,44 @@ renamed to \code{\link{SOMA}}.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{SCGroup$new()}}
-\item \href{#method-clone}{\code{SCGroup$clone()}}
+\item \href{#method-SCGroup-new}{\code{SCGroup$new()}}
+\item \href{#method-SCGroup-clone}{\code{SCGroup$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_member}{\code{tiledbsc::TileDBGroup$add_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_metadata}{\code{tiledbsc::TileDBGroup$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-count_members}{\code{tiledbsc::TileDBGroup$count_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_member}{\code{tiledbsc::TileDBGroup$get_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_members}{\code{tiledbsc::TileDBGroup$get_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_metadata}{\code{tiledbsc::TileDBGroup$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists">}\href{../../tiledbsc/html/TileDBGroup.html#method-group_exists}{\code{tiledbsc::TileDBGroup$group_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_member_uris}{\code{tiledbsc::TileDBGroup$list_member_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_members}{\code{tiledbsc::TileDBGroup$list_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_object_uris}{\code{tiledbsc::TileDBGroup$list_object_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_objects}{\code{tiledbsc::TileDBGroup$list_objects()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print">}\href{../../tiledbsc/html/TileDBGroup.html#method-print}{\code{tiledbsc::TileDBGroup$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group">}\href{../../tiledbsc/html/TileDBGroup.html#method-tiledb_group}{\code{tiledbsc::TileDBGroup$tiledb_group()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="add_seurat_dimreduction">}\href{../../tiledbsc/html/SOMA.html#method-add_seurat_dimreduction}{\code{tiledbsc::SOMA$add_seurat_dimreduction()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="from_seurat_assay">}\href{../../tiledbsc/html/SOMA.html#method-from_seurat_assay}{\code{tiledbsc::SOMA$from_seurat_assay()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="get_annotation_matrix_arrays">}\href{../../tiledbsc/html/SOMA.html#method-get_annotation_matrix_arrays}{\code{tiledbsc::SOMA$get_annotation_matrix_arrays()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="get_annotation_pairwise_matrix_arrays">}\href{../../tiledbsc/html/SOMA.html#method-get_annotation_pairwise_matrix_arrays}{\code{tiledbsc::SOMA$get_annotation_pairwise_matrix_arrays()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="get_seurat_dimreduction">}\href{../../tiledbsc/html/SOMA.html#method-get_seurat_dimreduction}{\code{tiledbsc::SOMA$get_seurat_dimreduction()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="get_seurat_dimreductions_list">}\href{../../tiledbsc/html/SOMA.html#method-get_seurat_dimreductions_list}{\code{tiledbsc::SOMA$get_seurat_dimreductions_list()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="to_seurat_assay">}\href{../../tiledbsc/html/SOMA.html#method-to_seurat_assay}{\code{tiledbsc::SOMA$to_seurat_assay()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="to_seurat_object">}\href{../../tiledbsc/html/SOMA.html#method-to_seurat_object}{\code{tiledbsc::SOMA$to_seurat_object()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="to_single_cell_experiment">}\href{../../tiledbsc/html/SOMA.html#method-to_single_cell_experiment}{\code{tiledbsc::SOMA$to_single_cell_experiment()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="to_summarized_experiment">}\href{../../tiledbsc/html/SOMA.html#method-to_summarized_experiment}{\code{tiledbsc::SOMA$to_summarized_experiment()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_member'><code>tiledbsc::TileDBGroup$add_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_metadata'><code>tiledbsc::TileDBGroup$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-count_members'><code>tiledbsc::TileDBGroup$count_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_member'><code>tiledbsc::TileDBGroup$get_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_members'><code>tiledbsc::TileDBGroup$get_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_metadata'><code>tiledbsc::TileDBGroup$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-group_exists'><code>tiledbsc::TileDBGroup$group_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_member_uris'><code>tiledbsc::TileDBGroup$list_member_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_members'><code>tiledbsc::TileDBGroup$list_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_object_uris'><code>tiledbsc::TileDBGroup$list_object_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_objects'><code>tiledbsc::TileDBGroup$list_objects()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-print'><code>tiledbsc::TileDBGroup$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-tiledb_group'><code>tiledbsc::TileDBGroup$tiledb_group()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="add_seurat_dimreduction"><a href='../../tiledbsc/html/SOMA.html#method-SOMA-add_seurat_dimreduction'><code>tiledbsc::SOMA$add_seurat_dimreduction()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="from_seurat_assay"><a href='../../tiledbsc/html/SOMA.html#method-SOMA-from_seurat_assay'><code>tiledbsc::SOMA$from_seurat_assay()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="get_annotation_matrix_arrays"><a href='../../tiledbsc/html/SOMA.html#method-SOMA-get_annotation_matrix_arrays'><code>tiledbsc::SOMA$get_annotation_matrix_arrays()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="get_annotation_pairwise_matrix_arrays"><a href='../../tiledbsc/html/SOMA.html#method-SOMA-get_annotation_pairwise_matrix_arrays'><code>tiledbsc::SOMA$get_annotation_pairwise_matrix_arrays()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="get_seurat_dimreduction"><a href='../../tiledbsc/html/SOMA.html#method-SOMA-get_seurat_dimreduction'><code>tiledbsc::SOMA$get_seurat_dimreduction()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="get_seurat_dimreductions_list"><a href='../../tiledbsc/html/SOMA.html#method-SOMA-get_seurat_dimreductions_list'><code>tiledbsc::SOMA$get_seurat_dimreductions_list()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="to_seurat_assay"><a href='../../tiledbsc/html/SOMA.html#method-SOMA-to_seurat_assay'><code>tiledbsc::SOMA$to_seurat_assay()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="to_seurat_object"><a href='../../tiledbsc/html/SOMA.html#method-SOMA-to_seurat_object'><code>tiledbsc::SOMA$to_seurat_object()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="to_single_cell_experiment"><a href='../../tiledbsc/html/SOMA.html#method-SOMA-to_single_cell_experiment'><code>tiledbsc::SOMA$to_single_cell_experiment()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="SOMA" data-id="to_summarized_experiment"><a href='../../tiledbsc/html/SOMA.html#method-SOMA-to_summarized_experiment'><code>tiledbsc::SOMA$to_summarized_experiment()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-SCGroup-new"></a>}}
+\if{latex}{\out{\hypertarget{method-SCGroup-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new SCGroup.
 \subsection{Usage}{
@@ -79,8 +79,8 @@ Create a new SCGroup.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-SCGroup-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-SCGroup-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/SOMA.Rd
+++ b/man/SOMA.Rd
@@ -45,44 +45,44 @@ dimensions of the \code{obs} and \code{var} arrays, respectively.}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{SOMA$new()}}
-\item \href{#method-from_seurat_assay}{\code{SOMA$from_seurat_assay()}}
-\item \href{#method-to_seurat_assay}{\code{SOMA$to_seurat_assay()}}
-\item \href{#method-add_seurat_dimreduction}{\code{SOMA$add_seurat_dimreduction()}}
-\item \href{#method-get_seurat_dimreduction}{\code{SOMA$get_seurat_dimreduction()}}
-\item \href{#method-get_seurat_dimreductions_list}{\code{SOMA$get_seurat_dimreductions_list()}}
-\item \href{#method-to_seurat_object}{\code{SOMA$to_seurat_object()}}
-\item \href{#method-to_summarized_experiment}{\code{SOMA$to_summarized_experiment()}}
-\item \href{#method-to_single_cell_experiment}{\code{SOMA$to_single_cell_experiment()}}
-\item \href{#method-get_annotation_matrix_arrays}{\code{SOMA$get_annotation_matrix_arrays()}}
-\item \href{#method-get_annotation_pairwise_matrix_arrays}{\code{SOMA$get_annotation_pairwise_matrix_arrays()}}
-\item \href{#method-clone}{\code{SOMA$clone()}}
+\item \href{#method-SOMA-new}{\code{SOMA$new()}}
+\item \href{#method-SOMA-from_seurat_assay}{\code{SOMA$from_seurat_assay()}}
+\item \href{#method-SOMA-to_seurat_assay}{\code{SOMA$to_seurat_assay()}}
+\item \href{#method-SOMA-add_seurat_dimreduction}{\code{SOMA$add_seurat_dimreduction()}}
+\item \href{#method-SOMA-get_seurat_dimreduction}{\code{SOMA$get_seurat_dimreduction()}}
+\item \href{#method-SOMA-get_seurat_dimreductions_list}{\code{SOMA$get_seurat_dimreductions_list()}}
+\item \href{#method-SOMA-to_seurat_object}{\code{SOMA$to_seurat_object()}}
+\item \href{#method-SOMA-to_summarized_experiment}{\code{SOMA$to_summarized_experiment()}}
+\item \href{#method-SOMA-to_single_cell_experiment}{\code{SOMA$to_single_cell_experiment()}}
+\item \href{#method-SOMA-get_annotation_matrix_arrays}{\code{SOMA$get_annotation_matrix_arrays()}}
+\item \href{#method-SOMA-get_annotation_pairwise_matrix_arrays}{\code{SOMA$get_annotation_pairwise_matrix_arrays()}}
+\item \href{#method-SOMA-clone}{\code{SOMA$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_member}{\code{tiledbsc::TileDBGroup$add_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_metadata}{\code{tiledbsc::TileDBGroup$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-count_members}{\code{tiledbsc::TileDBGroup$count_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_member}{\code{tiledbsc::TileDBGroup$get_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_members}{\code{tiledbsc::TileDBGroup$get_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_metadata}{\code{tiledbsc::TileDBGroup$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists">}\href{../../tiledbsc/html/TileDBGroup.html#method-group_exists}{\code{tiledbsc::TileDBGroup$group_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_member_uris}{\code{tiledbsc::TileDBGroup$list_member_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_members}{\code{tiledbsc::TileDBGroup$list_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_object_uris}{\code{tiledbsc::TileDBGroup$list_object_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_objects}{\code{tiledbsc::TileDBGroup$list_objects()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print">}\href{../../tiledbsc/html/TileDBGroup.html#method-print}{\code{tiledbsc::TileDBGroup$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group">}\href{../../tiledbsc/html/TileDBGroup.html#method-tiledb_group}{\code{tiledbsc::TileDBGroup$tiledb_group()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_member'><code>tiledbsc::TileDBGroup$add_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_metadata'><code>tiledbsc::TileDBGroup$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-count_members'><code>tiledbsc::TileDBGroup$count_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_member'><code>tiledbsc::TileDBGroup$get_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_members'><code>tiledbsc::TileDBGroup$get_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_metadata'><code>tiledbsc::TileDBGroup$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-group_exists'><code>tiledbsc::TileDBGroup$group_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_member_uris'><code>tiledbsc::TileDBGroup$list_member_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_members'><code>tiledbsc::TileDBGroup$list_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_object_uris'><code>tiledbsc::TileDBGroup$list_object_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_objects'><code>tiledbsc::TileDBGroup$list_objects()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-print'><code>tiledbsc::TileDBGroup$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-tiledb_group'><code>tiledbsc::TileDBGroup$tiledb_group()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-SOMA-new"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new SOMA. The existing array group is
 opened at the specified array \code{uri} if one is present, otherwise a new
@@ -106,8 +106,8 @@ array group is created.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-from_seurat_assay"></a>}}
-\if{latex}{\out{\hypertarget{method-from_seurat_assay}{}}}
+\if{html}{\out{<a id="method-SOMA-from_seurat_assay"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-from_seurat_assay}{}}}
 \subsection{Method \code{from_seurat_assay()}}{
 Convert a Seurat Assay to a TileDB-backed sc_group.
 \subsection{Usage}{
@@ -170,8 +170,8 @@ feature indicating whether it was a variable feature or not.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_seurat_assay"></a>}}
-\if{latex}{\out{\hypertarget{method-to_seurat_assay}{}}}
+\if{html}{\out{<a id="method-SOMA-to_seurat_assay"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-to_seurat_assay}{}}}
 \subsection{Method \code{to_seurat_assay()}}{
 Convert to a \code{\link[SeuratObject:Assay-class]{SeuratObject::Assay}} object.
 \subsection{Usage}{
@@ -206,8 +206,8 @@ values}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-add_seurat_dimreduction"></a>}}
-\if{latex}{\out{\hypertarget{method-add_seurat_dimreduction}{}}}
+\if{html}{\out{<a id="method-SOMA-add_seurat_dimreduction"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-add_seurat_dimreduction}{}}}
 \subsection{Method \code{add_seurat_dimreduction()}}{
 Convert a \code{\link[SeuratObject:DimReduc-class]{SeuratObject::DimReduc}} object
 \subsection{Usage}{
@@ -249,8 +249,8 @@ results column names (required by Seurat)
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_seurat_dimreduction"></a>}}
-\if{latex}{\out{\hypertarget{method-get_seurat_dimreduction}{}}}
+\if{html}{\out{<a id="method-SOMA-get_seurat_dimreduction"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-get_seurat_dimreduction}{}}}
 \subsection{Method \code{get_seurat_dimreduction()}}{
 Convert to a \code{\link[SeuratObject:DimReduc-class]{SeuratObject::DimReduc}} object.
 \subsection{Usage}{
@@ -268,8 +268,8 @@ default to the first \code{obsm/dimreduction_} array.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_seurat_dimreductions_list"></a>}}
-\if{latex}{\out{\hypertarget{method-get_seurat_dimreductions_list}{}}}
+\if{html}{\out{<a id="method-SOMA-get_seurat_dimreductions_list"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-get_seurat_dimreductions_list}{}}}
 \subsection{Method \code{get_seurat_dimreductions_list()}}{
 Retrieve a list of all \code{\link[SeuratObject:DimReduc-class]{SeuratObject::DimReduc}} objects.
 \subsection{Usage}{
@@ -278,8 +278,8 @@ Retrieve a list of all \code{\link[SeuratObject:DimReduc-class]{SeuratObject::Di
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_seurat_object"></a>}}
-\if{latex}{\out{\hypertarget{method-to_seurat_object}{}}}
+\if{html}{\out{<a id="method-SOMA-to_seurat_object"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-to_seurat_object}{}}}
 \subsection{Method \code{to_seurat_object()}}{
 Convert to a \link[SeuratObject:Seurat-class]{SeuratObject::Seurat} object.
 \subsection{Usage}{
@@ -295,8 +295,8 @@ Convert to a \link[SeuratObject:Seurat-class]{SeuratObject::Seurat} object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_summarized_experiment"></a>}}
-\if{latex}{\out{\hypertarget{method-to_summarized_experiment}{}}}
+\if{html}{\out{<a id="method-SOMA-to_summarized_experiment"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-to_summarized_experiment}{}}}
 \subsection{Method \code{to_summarized_experiment()}}{
 Convert to a \link[SummarizedExperiment:RangedSummarizedExperiment-class]{SummarizedExperiment::SummarizedExperiment}
 object.
@@ -325,8 +325,8 @@ with a subset of features is included.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_single_cell_experiment"></a>}}
-\if{latex}{\out{\hypertarget{method-to_single_cell_experiment}{}}}
+\if{html}{\out{<a id="method-SOMA-to_single_cell_experiment"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-to_single_cell_experiment}{}}}
 \subsection{Method \code{to_single_cell_experiment()}}{
 Convert to a Bioconductor
 \link[SingleCellExperiment:SingleCellExperiment]{SingleCellExperiment::SingleCellExperiment} object.
@@ -346,8 +346,8 @@ of the layers vector.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_annotation_matrix_arrays"></a>}}
-\if{latex}{\out{\hypertarget{method-get_annotation_matrix_arrays}{}}}
+\if{html}{\out{<a id="method-SOMA-get_annotation_matrix_arrays"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-get_annotation_matrix_arrays}{}}}
 \subsection{Method \code{get_annotation_matrix_arrays()}}{
 Retrieve \code{\link{AnnotationMatrix}} arrays in \code{obsm}/\code{varm}
 groups.
@@ -368,8 +368,8 @@ the prefix.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_annotation_pairwise_matrix_arrays"></a>}}
-\if{latex}{\out{\hypertarget{method-get_annotation_pairwise_matrix_arrays}{}}}
+\if{html}{\out{<a id="method-SOMA-get_annotation_pairwise_matrix_arrays"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-get_annotation_pairwise_matrix_arrays}{}}}
 \subsection{Method \code{get_annotation_pairwise_matrix_arrays()}}{
 Retrieve \code{\link{AnnotationPairwiseMatrix}} arrays in
 \code{obsp}/\code{varp} groups.
@@ -390,8 +390,8 @@ the prefix.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-SOMA-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMA-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/SOMACollection.Rd
+++ b/man/SOMACollection.Rd
@@ -27,37 +27,37 @@ Class for representing a \code{SOMACollection}, which may contain of one or more
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{SOMACollection$new()}}
-\item \href{#method-from_seurat}{\code{SOMACollection$from_seurat()}}
-\item \href{#method-to_seurat}{\code{SOMACollection$to_seurat()}}
-\item \href{#method-soma_uris}{\code{SOMACollection$soma_uris()}}
-\item \href{#method-clone}{\code{SOMACollection$clone()}}
+\item \href{#method-SOMACollection-new}{\code{SOMACollection$new()}}
+\item \href{#method-SOMACollection-from_seurat}{\code{SOMACollection$from_seurat()}}
+\item \href{#method-SOMACollection-to_seurat}{\code{SOMACollection$to_seurat()}}
+\item \href{#method-SOMACollection-soma_uris}{\code{SOMACollection$soma_uris()}}
+\item \href{#method-SOMACollection-clone}{\code{SOMACollection$clone()}}
 }
 }
-\if{html}{
-\out{<details ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_member}{\code{tiledbsc::TileDBGroup$add_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-add_metadata}{\code{tiledbsc::TileDBGroup$add_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-count_members}{\code{tiledbsc::TileDBGroup$count_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_member}{\code{tiledbsc::TileDBGroup$get_member()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_members}{\code{tiledbsc::TileDBGroup$get_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata">}\href{../../tiledbsc/html/TileDBGroup.html#method-get_metadata}{\code{tiledbsc::TileDBGroup$get_metadata()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists">}\href{../../tiledbsc/html/TileDBGroup.html#method-group_exists}{\code{tiledbsc::TileDBGroup$group_exists()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_member_uris}{\code{tiledbsc::TileDBGroup$list_member_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_members}{\code{tiledbsc::TileDBGroup$list_members()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_object_uris}{\code{tiledbsc::TileDBGroup$list_object_uris()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects">}\href{../../tiledbsc/html/TileDBGroup.html#method-list_objects}{\code{tiledbsc::TileDBGroup$list_objects()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print">}\href{../../tiledbsc/html/TileDBGroup.html#method-print}{\code{tiledbsc::TileDBGroup$print()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group">}\href{../../tiledbsc/html/TileDBGroup.html#method-tiledb_group}{\code{tiledbsc::TileDBGroup$tiledb_group()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_member'><code>tiledbsc::TileDBGroup$add_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="add_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-add_metadata'><code>tiledbsc::TileDBGroup$add_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="count_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-count_members'><code>tiledbsc::TileDBGroup$count_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_member"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_member'><code>tiledbsc::TileDBGroup$get_member()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_members'><code>tiledbsc::TileDBGroup$get_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="get_metadata"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-get_metadata'><code>tiledbsc::TileDBGroup$get_metadata()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="group_exists"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-group_exists'><code>tiledbsc::TileDBGroup$group_exists()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_member_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_member_uris'><code>tiledbsc::TileDBGroup$list_member_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_members"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_members'><code>tiledbsc::TileDBGroup$list_members()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_object_uris"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_object_uris'><code>tiledbsc::TileDBGroup$list_object_uris()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="list_objects"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-list_objects'><code>tiledbsc::TileDBGroup$list_objects()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="print"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-print'><code>tiledbsc::TileDBGroup$print()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBGroup" data-id="tiledb_group"><a href='../../tiledbsc/html/TileDBGroup.html#method-TileDBGroup-tiledb_group'><code>tiledbsc::TileDBGroup$tiledb_group()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-SOMACollection-new"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMACollection-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new \code{SOMACollection}. The existing TileDB group is
 opened at the specified array \code{uri} if one is present, otherwise a new
@@ -84,8 +84,8 @@ TileDB group.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-from_seurat"></a>}}
-\if{latex}{\out{\hypertarget{method-from_seurat}{}}}
+\if{html}{\out{<a id="method-SOMACollection-from_seurat"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMACollection-from_seurat}{}}}
 \subsection{Method \code{from_seurat()}}{
 Convert a Seurat object to a TileDB-backed \code{SOMACollection}.
 \subsection{Assays}{
@@ -123,8 +123,8 @@ dimensionality reduction method (e.g., \code{"pca"}).
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-to_seurat"></a>}}
-\if{latex}{\out{\hypertarget{method-to_seurat}{}}}
+\if{html}{\out{<a id="method-SOMACollection-to_seurat"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMACollection-to_seurat}{}}}
 \subsection{Method \code{to_seurat()}}{
 Convert to a \link[SeuratObject:Seurat-class]{SeuratObject::Seurat} object.
 \subsection{Usage}{
@@ -140,8 +140,8 @@ Convert to a \link[SeuratObject:Seurat-class]{SeuratObject::Seurat} object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-soma_uris"></a>}}
-\if{latex}{\out{\hypertarget{method-soma_uris}{}}}
+\if{html}{\out{<a id="method-SOMACollection-soma_uris"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMACollection-soma_uris}{}}}
 \subsection{Method \code{soma_uris()}}{
 List the \code{\link{SOMA}} URIs in the collection.
 \subsection{Usage}{
@@ -153,8 +153,8 @@ A vector of URIs for each \code{\link{SOMA}} in the collection.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-SOMACollection-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-SOMACollection-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/TileDBArray.Rd
+++ b/man/TileDBArray.Rd
@@ -21,32 +21,32 @@ populate the private \code{create_empty_array()} and \code{ingest_data()} method
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{TileDBArray$new()}}
-\item \href{#method-print}{\code{TileDBArray$print()}}
-\item \href{#method-array_exists}{\code{TileDBArray$array_exists()}}
-\item \href{#method-tiledb_array}{\code{TileDBArray$tiledb_array()}}
-\item \href{#method-get_metadata}{\code{TileDBArray$get_metadata()}}
-\item \href{#method-add_metadata}{\code{TileDBArray$add_metadata()}}
-\item \href{#method-schema}{\code{TileDBArray$schema()}}
-\item \href{#method-dimensions}{\code{TileDBArray$dimensions()}}
-\item \href{#method-attributes}{\code{TileDBArray$attributes()}}
-\item \href{#method-dimnames}{\code{TileDBArray$dimnames()}}
-\item \href{#method-fragment_count}{\code{TileDBArray$fragment_count()}}
-\item \href{#method-attrnames}{\code{TileDBArray$attrnames()}}
-\item \href{#method-clone}{\code{TileDBArray$clone()}}
+\item \href{#method-TileDBArray-new}{\code{TileDBArray$new()}}
+\item \href{#method-TileDBArray-print}{\code{TileDBArray$print()}}
+\item \href{#method-TileDBArray-array_exists}{\code{TileDBArray$array_exists()}}
+\item \href{#method-TileDBArray-tiledb_array}{\code{TileDBArray$tiledb_array()}}
+\item \href{#method-TileDBArray-get_metadata}{\code{TileDBArray$get_metadata()}}
+\item \href{#method-TileDBArray-add_metadata}{\code{TileDBArray$add_metadata()}}
+\item \href{#method-TileDBArray-schema}{\code{TileDBArray$schema()}}
+\item \href{#method-TileDBArray-dimensions}{\code{TileDBArray$dimensions()}}
+\item \href{#method-TileDBArray-attributes}{\code{TileDBArray$attributes()}}
+\item \href{#method-TileDBArray-dimnames}{\code{TileDBArray$dimnames()}}
+\item \href{#method-TileDBArray-fragment_count}{\code{TileDBArray$fragment_count()}}
+\item \href{#method-TileDBArray-attrnames}{\code{TileDBArray$attrnames()}}
+\item \href{#method-TileDBArray-clone}{\code{TileDBArray$clone()}}
 }
 }
-\if{html}{
-\out{<details open ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details open><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-TileDBArray-new"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new TileDBArray object.
 \subsection{Usage}{
@@ -68,8 +68,8 @@ Create a new TileDBArray object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-print"></a>}}
-\if{latex}{\out{\hypertarget{method-print}{}}}
+\if{html}{\out{<a id="method-TileDBArray-print"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-print}{}}}
 \subsection{Method \code{print()}}{
 Print summary of the array.
 \subsection{Usage}{
@@ -78,8 +78,8 @@ Print summary of the array.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-array_exists"></a>}}
-\if{latex}{\out{\hypertarget{method-array_exists}{}}}
+\if{html}{\out{<a id="method-TileDBArray-array_exists"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-array_exists}{}}}
 \subsection{Method \code{array_exists()}}{
 Check if the array exists.
 \subsection{Usage}{
@@ -91,8 +91,8 @@ TRUE if the array exists, FALSE otherwise.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-tiledb_array"></a>}}
-\if{latex}{\out{\hypertarget{method-tiledb_array}{}}}
+\if{html}{\out{<a id="method-TileDBArray-tiledb_array"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-tiledb_array}{}}}
 \subsection{Method \code{tiledb_array()}}{
 Return a \code{\link{TileDBArray}} object
 \subsection{Usage}{
@@ -111,8 +111,8 @@ A \code{\link[tiledb:tiledb_array]{tiledb::tiledb_array}} object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_metadata"></a>}}
-\if{latex}{\out{\hypertarget{method-get_metadata}{}}}
+\if{html}{\out{<a id="method-TileDBArray-get_metadata"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-get_metadata}{}}}
 \subsection{Method \code{get_metadata()}}{
 Retrieve metadata from the TileDB array.
 \subsection{Usage}{
@@ -134,8 +134,8 @@ A list of metadata values.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-add_metadata"></a>}}
-\if{latex}{\out{\hypertarget{method-add_metadata}{}}}
+\if{html}{\out{<a id="method-TileDBArray-add_metadata"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-add_metadata}{}}}
 \subsection{Method \code{add_metadata()}}{
 Add list of metadata to the specified TileDB array.
 \subsection{Usage}{
@@ -156,8 +156,8 @@ NULL
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-schema"></a>}}
-\if{latex}{\out{\hypertarget{method-schema}{}}}
+\if{html}{\out{<a id="method-TileDBArray-schema"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-schema}{}}}
 \subsection{Method \code{schema()}}{
 Retrieve the array schema
 \subsection{Usage}{
@@ -169,8 +169,8 @@ A \code{\link[tiledb:tiledb_array_schema]{tiledb::tiledb_array_schema}} object
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-dimensions"></a>}}
-\if{latex}{\out{\hypertarget{method-dimensions}{}}}
+\if{html}{\out{<a id="method-TileDBArray-dimensions"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-dimensions}{}}}
 \subsection{Method \code{dimensions()}}{
 Retrieve the array dimensions
 \subsection{Usage}{
@@ -182,8 +182,8 @@ A list of \code{\link[tiledb:tiledb_dim]{tiledb::tiledb_dim}} objects
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-attributes"></a>}}
-\if{latex}{\out{\hypertarget{method-attributes}{}}}
+\if{html}{\out{<a id="method-TileDBArray-attributes"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-attributes}{}}}
 \subsection{Method \code{attributes()}}{
 Retrieve the array attributes
 \subsection{Usage}{
@@ -195,8 +195,8 @@ A list of \code{\link[tiledb:tiledb_attr]{tiledb::tiledb_attr}} objects
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-dimnames"></a>}}
-\if{latex}{\out{\hypertarget{method-dimnames}{}}}
+\if{html}{\out{<a id="method-TileDBArray-dimnames"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-dimnames}{}}}
 \subsection{Method \code{dimnames()}}{
 Retrieve dimension names
 \subsection{Usage}{
@@ -208,8 +208,8 @@ A character vector with the array's dimension names
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-fragment_count"></a>}}
-\if{latex}{\out{\hypertarget{method-fragment_count}{}}}
+\if{html}{\out{<a id="method-TileDBArray-fragment_count"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-fragment_count}{}}}
 \subsection{Method \code{fragment_count()}}{
 Get number of fragments in the array
 \subsection{Usage}{
@@ -218,8 +218,8 @@ Get number of fragments in the array
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-attrnames"></a>}}
-\if{latex}{\out{\hypertarget{method-attrnames}{}}}
+\if{html}{\out{<a id="method-TileDBArray-attrnames"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-attrnames}{}}}
 \subsection{Method \code{attrnames()}}{
 Retrieve attribute names
 \subsection{Usage}{
@@ -231,8 +231,8 @@ A character vector with the array's attribute names
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-TileDBArray-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBArray-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/TileDBGroup.Rd
+++ b/man/TileDBGroup.Rd
@@ -31,34 +31,34 @@ the specified \code{uri}.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{TileDBGroup$new()}}
-\item \href{#method-print}{\code{TileDBGroup$print()}}
-\item \href{#method-group_exists}{\code{TileDBGroup$group_exists()}}
-\item \href{#method-tiledb_group}{\code{TileDBGroup$tiledb_group()}}
-\item \href{#method-list_objects}{\code{TileDBGroup$list_objects()}}
-\item \href{#method-list_object_uris}{\code{TileDBGroup$list_object_uris()}}
-\item \href{#method-add_member}{\code{TileDBGroup$add_member()}}
-\item \href{#method-count_members}{\code{TileDBGroup$count_members()}}
-\item \href{#method-list_members}{\code{TileDBGroup$list_members()}}
-\item \href{#method-list_member_uris}{\code{TileDBGroup$list_member_uris()}}
-\item \href{#method-get_members}{\code{TileDBGroup$get_members()}}
-\item \href{#method-get_member}{\code{TileDBGroup$get_member()}}
-\item \href{#method-get_metadata}{\code{TileDBGroup$get_metadata()}}
-\item \href{#method-add_metadata}{\code{TileDBGroup$add_metadata()}}
-\item \href{#method-clone}{\code{TileDBGroup$clone()}}
+\item \href{#method-TileDBGroup-new}{\code{TileDBGroup$new()}}
+\item \href{#method-TileDBGroup-print}{\code{TileDBGroup$print()}}
+\item \href{#method-TileDBGroup-group_exists}{\code{TileDBGroup$group_exists()}}
+\item \href{#method-TileDBGroup-tiledb_group}{\code{TileDBGroup$tiledb_group()}}
+\item \href{#method-TileDBGroup-list_objects}{\code{TileDBGroup$list_objects()}}
+\item \href{#method-TileDBGroup-list_object_uris}{\code{TileDBGroup$list_object_uris()}}
+\item \href{#method-TileDBGroup-add_member}{\code{TileDBGroup$add_member()}}
+\item \href{#method-TileDBGroup-count_members}{\code{TileDBGroup$count_members()}}
+\item \href{#method-TileDBGroup-list_members}{\code{TileDBGroup$list_members()}}
+\item \href{#method-TileDBGroup-list_member_uris}{\code{TileDBGroup$list_member_uris()}}
+\item \href{#method-TileDBGroup-get_members}{\code{TileDBGroup$get_members()}}
+\item \href{#method-TileDBGroup-get_member}{\code{TileDBGroup$get_member()}}
+\item \href{#method-TileDBGroup-get_metadata}{\code{TileDBGroup$get_metadata()}}
+\item \href{#method-TileDBGroup-add_metadata}{\code{TileDBGroup$add_metadata()}}
+\item \href{#method-TileDBGroup-clone}{\code{TileDBGroup$clone()}}
 }
 }
-\if{html}{
-\out{<details open ><summary>Inherited methods</summary>}
-\itemize{
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class">}\href{../../tiledbsc/html/TileDBObject.html#method-class}{\code{tiledbsc::TileDBObject$class()}}\out{</span>}
-\item \out{<span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists">}\href{../../tiledbsc/html/TileDBObject.html#method-exists}{\code{tiledbsc::TileDBObject$exists()}}\out{</span>}
-}
-\out{</details>}
-}
+\if{html}{\out{
+<details open><summary>Inherited methods</summary>
+<ul>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="class"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-class'><code>tiledbsc::TileDBObject$class()</code></a></li>
+<li><span class="pkg-link" data-pkg="tiledbsc" data-topic="TileDBObject" data-id="exists"><a href='../../tiledbsc/html/TileDBObject.html#method-TileDBObject-exists'><code>tiledbsc::TileDBObject$exists()</code></a></li>
+</ul>
+</details>
+}}
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-new"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new TileDBGroup object.
 \subsection{Usage}{
@@ -80,8 +80,8 @@ Create a new TileDBGroup object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-print"></a>}}
-\if{latex}{\out{\hypertarget{method-print}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-print"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-print}{}}}
 \subsection{Method \code{print()}}{
 Print summary of the group.
 \subsection{Usage}{
@@ -90,8 +90,8 @@ Print summary of the group.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-group_exists"></a>}}
-\if{latex}{\out{\hypertarget{method-group_exists}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-group_exists"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-group_exists}{}}}
 \subsection{Method \code{group_exists()}}{
 Check if the group exists.
 \subsection{Usage}{
@@ -103,8 +103,8 @@ TRUE if the group exists, FALSE otherwise.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-tiledb_group"></a>}}
-\if{latex}{\out{\hypertarget{method-tiledb_group}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-tiledb_group"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-tiledb_group}{}}}
 \subsection{Method \code{tiledb_group()}}{
 Return a \code{\link{tiledb_group}} object
 \subsection{Usage}{
@@ -123,8 +123,8 @@ A \code{\link[tiledb:tiledb_group]{tiledb::tiledb_group}} object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-list_objects"></a>}}
-\if{latex}{\out{\hypertarget{method-list_objects}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-list_objects"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-list_objects}{}}}
 \subsection{Method \code{list_objects()}}{
 List the TileDB objects within the group.
 \subsection{Usage}{
@@ -144,8 +144,8 @@ A \code{data.frame} with columns \code{URI} and \code{TYPE}.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-list_object_uris"></a>}}
-\if{latex}{\out{\hypertarget{method-list_object_uris}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-list_object_uris"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-list_object_uris}{}}}
 \subsection{Method \code{list_object_uris()}}{
 List URIs for TileDB objects within the group.
 \subsection{Usage}{
@@ -168,8 +168,8 @@ basename of the object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-add_member"></a>}}
-\if{latex}{\out{\hypertarget{method-add_member}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-add_member"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-add_member}{}}}
 \subsection{Method \code{add_member()}}{
 Add new member to the group.
 \subsection{Usage}{
@@ -191,8 +191,8 @@ is relative to the group's URI.}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-count_members"></a>}}
-\if{latex}{\out{\hypertarget{method-count_members}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-count_members"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-count_members}{}}}
 \subsection{Method \code{count_members()}}{
 Count the number of members in the group.
 \subsection{Usage}{
@@ -204,8 +204,8 @@ Integer count of members in the group.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-list_members"></a>}}
-\if{latex}{\out{\hypertarget{method-list_members}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-list_members"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-list_members}{}}}
 \subsection{Method \code{list_members()}}{
 List the members of the group.
 \subsection{Usage}{
@@ -225,8 +225,8 @@ A \code{data.frame} with columns \code{URI}, \code{TYPE}, and \code{NAME}.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-list_member_uris"></a>}}
-\if{latex}{\out{\hypertarget{method-list_member_uris}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-list_member_uris"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-list_member_uris}{}}}
 \subsection{Method \code{list_member_uris()}}{
 List URIs for group members
 \subsection{Usage}{
@@ -248,8 +248,8 @@ A character vector of member URIs, named for the group member
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_members"></a>}}
-\if{latex}{\out{\hypertarget{method-get_members}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-get_members"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-get_members}{}}}
 \subsection{Method \code{get_members()}}{
 Retrieve arrays within the group that meet the specified
 criteria.
@@ -269,8 +269,8 @@ criteria.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_member"></a>}}
-\if{latex}{\out{\hypertarget{method-get_member}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-get_member"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-get_member}{}}}
 \subsection{Method \code{get_member()}}{
 Retrieve a group member.
 \subsection{Usage}{
@@ -286,8 +286,8 @@ Retrieve a group member.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-get_metadata"></a>}}
-\if{latex}{\out{\hypertarget{method-get_metadata}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-get_metadata"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-get_metadata}{}}}
 \subsection{Method \code{get_metadata()}}{
 Retrieve metadata from the TileDB group.
 \subsection{Usage}{
@@ -309,8 +309,8 @@ A list of metadata values.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-add_metadata"></a>}}
-\if{latex}{\out{\hypertarget{method-add_metadata}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-add_metadata"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-add_metadata}{}}}
 \subsection{Method \code{add_metadata()}}{
 Add list of metadata to the TileDB group.
 \subsection{Usage}{
@@ -331,8 +331,8 @@ NULL
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-TileDBGroup-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBGroup-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/man/TileDBObject.Rd
+++ b/man/TileDBObject.Rd
@@ -22,22 +22,25 @@ TileDBGroup classes.
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
 \item{\code{uri}}{The URI of the TileDB object.}
+
+\item{\code{object}}{Access the underlying TileB object directly (either a
+\code{\link[tiledb:tiledb_array]{tiledb::tiledb_array}} or \code{\link[tiledb:tiledb_group]{tiledb::tiledb_group}}).}
 }
 \if{html}{\out{</div>}}
 }
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{TileDBObject$new()}}
-\item \href{#method-class}{\code{TileDBObject$class()}}
-\item \href{#method-print}{\code{TileDBObject$print()}}
-\item \href{#method-exists}{\code{TileDBObject$exists()}}
-\item \href{#method-clone}{\code{TileDBObject$clone()}}
+\item \href{#method-TileDBObject-new}{\code{TileDBObject$new()}}
+\item \href{#method-TileDBObject-class}{\code{TileDBObject$class()}}
+\item \href{#method-TileDBObject-print}{\code{TileDBObject$print()}}
+\item \href{#method-TileDBObject-exists}{\code{TileDBObject$exists()}}
+\item \href{#method-TileDBObject-clone}{\code{TileDBObject$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-TileDBObject-new"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBObject-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new TileDB object.
 \subsection{Usage}{
@@ -59,8 +62,8 @@ Create a new TileDB object.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-class"></a>}}
-\if{latex}{\out{\hypertarget{method-class}{}}}
+\if{html}{\out{<a id="method-TileDBObject-class"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBObject-class}{}}}
 \subsection{Method \code{class()}}{
 Print the name of the R6 class.
 \subsection{Usage}{
@@ -69,8 +72,8 @@ Print the name of the R6 class.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-print"></a>}}
-\if{latex}{\out{\hypertarget{method-print}{}}}
+\if{html}{\out{<a id="method-TileDBObject-print"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBObject-print}{}}}
 \subsection{Method \code{print()}}{
 Print summary of the array.
 \subsection{Usage}{
@@ -79,8 +82,8 @@ Print summary of the array.
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-exists"></a>}}
-\if{latex}{\out{\hypertarget{method-exists}{}}}
+\if{html}{\out{<a id="method-TileDBObject-exists"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBObject-exists}{}}}
 \subsection{Method \code{exists()}}{
 Check if the object exists.
 \subsection{Usage}{
@@ -92,8 +95,8 @@ Check if the object exists.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-clone}{}}}
+\if{html}{\out{<a id="method-TileDBObject-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-TileDBObject-clone}{}}}
 \subsection{Method \code{clone()}}{
 The objects of this class are cloneable with this method.
 \subsection{Usage}{

--- a/tests/testthat/test_AnnotationDataFrame.R
+++ b/tests/testthat/test_AnnotationDataFrame.R
@@ -1,5 +1,5 @@
 test_that("annotation dataframe can be stored and retrieved", {
-  uri <- withr::local_tempdir("annot-df")
+  uri <- withr::local_tempdir("annot-df16")
 
   annotdf <- AnnotationDataframe$new(uri)
   expect_true(inherits(annotdf, "AnnotationDataframe"))
@@ -10,7 +10,9 @@ test_that("annotation dataframe can be stored and retrieved", {
 
   annotdf$from_dataframe(mtcars, index_col = "index")
   expect_true(dir.exists(annotdf$uri))
+  expect_true(annotdf$exists())
   expect_s4_class(annotdf$tiledb_array(), "tiledb_array")
+  expect_is(annotdf$object, "tiledb_array")
 
   mtcars2 <- annotdf$to_dataframe()
   expect_equal(sort(rownames(mtcars2)), sort(rownames(mtcars)))

--- a/tests/testthat/test_TileDBArray.R
+++ b/tests/testthat/test_TileDBArray.R
@@ -2,8 +2,13 @@ test_that("TileDBArray helper functions", {
   uri <- withr::local_tempdir(pattern = "test-array")
 
   expect_message(
-    TileDBArray$new(uri = uri, verbose = TRUE),
+    tdb <- TileDBArray$new(uri = uri, verbose = TRUE),
     "No TileDBArray found at"
+  )
+
+  expect_error(
+    tdb$get_object(),
+    "TileDB object does not exist"
   )
 
   # create an array
@@ -17,6 +22,7 @@ test_that("TileDBArray helper functions", {
   )
   expect_identical(tdb$uri, uri)
   expect_is(tdb$tiledb_array(), "tiledb_array")
+  expect_is(tdb$get_object(), "tiledb_array")
   expect_identical(tdb$dimnames(), index_cols)
 
   attr_cols <- setdiff(colnames(df), index_cols)

--- a/tests/testthat/test_TileDBArray.R
+++ b/tests/testthat/test_TileDBArray.R
@@ -7,7 +7,7 @@ test_that("TileDBArray helper functions", {
   )
 
   expect_error(
-    tdb$get_object(),
+    tdb$object,
     "TileDB object does not exist"
   )
 
@@ -22,7 +22,7 @@ test_that("TileDBArray helper functions", {
   )
   expect_identical(tdb$uri, uri)
   expect_is(tdb$tiledb_array(), "tiledb_array")
-  expect_is(tdb$get_object(), "tiledb_array")
+  expect_is(tdb$object, "tiledb_array")
   expect_identical(tdb$dimnames(), index_cols)
 
   attr_cols <- setdiff(colnames(df), index_cols)

--- a/tests/testthat/test_TileDBGroup.R
+++ b/tests/testthat/test_TileDBGroup.R
@@ -15,7 +15,7 @@ test_that("members can be added and retrieved from a new group", {
   grp_uri <- withr::local_tempdir("new-group")
   grp <- TileDBGroup$new(uri = grp_uri, verbose = FALSE)
   expect_is(grp$tiledb_group(), "tiledb_group")
-  expect_is(grp$get_object(), "tiledb_group")
+  expect_is(grp$object, "tiledb_group")
 
   expect_equal(grp$count_members(), 0)
 

--- a/tests/testthat/test_TileDBGroup.R
+++ b/tests/testthat/test_TileDBGroup.R
@@ -15,6 +15,7 @@ test_that("members can be added and retrieved from a new group", {
   grp_uri <- withr::local_tempdir("new-group")
   grp <- TileDBGroup$new(uri = grp_uri, verbose = FALSE)
   expect_is(grp$tiledb_group(), "tiledb_group")
+  expect_is(grp$get_object(), "tiledb_group")
 
   expect_equal(grp$count_members(), 0)
 


### PR DESCRIPTION
These changes pave the way for implementing dimension slicing and attribute filtering.

Similar to the `TileDBGroup` class, `TileDBArray` now maintains a reference to the underlying array pointer. Both classes store the reference in `private$tiledb_object`. Users can access the object via the `objects` field. 

The `objects` field is implemented as active binding to prevent it from being overwritten and to check whether it needs to be initialized, as is this case when TileDB arrays are created on disk after instantiating a `TileDBArray` object.

All changes:

- All classes gain a `objects` field to access the underlying TileDB objects directly
- Store TileDBGroup's internal pointer in `private$tiledb_object`
- Store internal reference to the tiledb_array object in `private$tiledb_object`
- Update `AnnotationArray` and `AnnotationDataframe` ingestion paths to use new internal object
