### PR TITLE
Write object-type and SOMA-version metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.2.9004
+Version: 0.1.2.9005
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,7 @@ See the new *Filtering* vignette for details.
 - All classes gain an `objects` field to provide direct access to the underlying TileDB objects
 - Added missing `config`/`ctx` fields to `AnnotationGroup`
 - `AnnotationDataframe` gains `ids()` to retrieve all values from the array's dimension
+- `soma_object_type` and `soma_encoding_version` metadata are written to groups/arrays at write time
 
 # tiledbsc 0.1.2
 

--- a/R/AnnotationArray.R
+++ b/R/AnnotationArray.R
@@ -47,6 +47,7 @@ AnnotationArray <- R6::R6Class(
         capacity = capacity,
         mode = "schema_only"
       )
+      private$write_object_type_metadata()
     },
 
     # @description Ingest assay/annotation data into the TileDB array

--- a/R/AssayMatrix.R
+++ b/R/AssayMatrix.R
@@ -183,6 +183,7 @@ AssayMatrix <- R6::R6Class(
 
       private$log_array_creation(index_cols)
       tiledb::tiledb_array_create(uri = self$uri, schema = tdb_schema)
+      private$write_object_type_metadata()
     },
 
     # @description Ingest assay data into the TileDB array.

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -182,6 +182,14 @@ TileDBArray <- R6::R6Class(
         query_layout = "UNORDERED"
       )
       private$close()
+      private$write_object_type_metadata()
+    },
+
+    write_object_type_metadata = function() {
+      meta <- list()
+      meta[[SOMA_OBJECT_TYPE_METADATA_KEY]] <- class(self)[1]
+      meta[[SOMA_ENCODING_VERSION_METADATA_KEY]] <- SOMA_ENCODING_VERSION
+      self$add_metadata(meta) # TileDBArray or TileDBGroup
     },
 
     # @description Create empty TileDB array.

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -182,7 +182,6 @@ TileDBArray <- R6::R6Class(
         query_layout = "UNORDERED"
       )
       private$close()
-      private$write_object_type_metadata()
     },
 
     write_object_type_metadata = function() {

--- a/R/TileDBGroup.R
+++ b/R/TileDBGroup.R
@@ -270,6 +270,7 @@ TileDBGroup <- R6::R6Class(
         message(sprintf("Creating new %s at '%s'", self$class(), self$uri))
       }
       tiledb::tiledb_group_create(self$uri, ctx = self$ctx)
+      private$write_object_type_metadata()
     },
 
     open = function(mode) {
@@ -284,7 +285,6 @@ TileDBGroup <- R6::R6Class(
     initialize_object = function() {
       private$tiledb_object <- tiledb::tiledb_group(self$uri, ctx = self$ctx)
       private$close()
-      private$write_object_type_metadata()
     },
 
     write_object_type_metadata = function() {

--- a/R/TileDBGroup.R
+++ b/R/TileDBGroup.R
@@ -284,6 +284,14 @@ TileDBGroup <- R6::R6Class(
     initialize_object = function() {
       private$tiledb_object <- tiledb::tiledb_group(self$uri, ctx = self$ctx)
       private$close()
+      private$write_object_type_metadata()
+    },
+
+    write_object_type_metadata = function() {
+      meta <- list()
+      meta[[SOMA_OBJECT_TYPE_METADATA_KEY]] <- class(self)[1]
+      meta[[SOMA_ENCODING_VERSION_METADATA_KEY]] <- SOMA_ENCODING_VERSION
+      self$add_metadata(meta) # TileDBArray or TileDBGroup
     },
 
     # Instantiate existing group members

--- a/R/TileDBObject.R
+++ b/R/TileDBObject.R
@@ -103,5 +103,6 @@ TileDBObject <- R6::R6Class(
 
     # @description Contains TileDBURI object
     tiledb_uri = NULL
+
   )
 )

--- a/R/utils.R
+++ b/R/utils.R
@@ -117,3 +117,7 @@ assert_subset <- function(x, y, type = "value") {
   }
   TRUE
 }
+
+SOMA_OBJECT_TYPE_METADATA_KEY <- "soma_object_type"
+SOMA_ENCODING_VERSION_METADATA_KEY <- "soma_encoding_version"
+SOMA_ENCODING_VERSION <- "0"

--- a/tests/testthat/test_TileDBGroup.R
+++ b/tests/testthat/test_TileDBGroup.R
@@ -129,5 +129,9 @@ test_that("metadata can be set and retrieved from a group", {
   grp$add_metadata(md)
   expect_equivalent(grp$get_metadata(key = "foo"), "bar")
   expect_equivalent(grp$get_metadata(prefix = "foo"), md["foo"])
-  expect_equivalent(grp$get_metadata(), md)
+  # There are system-added metadata values so we shouldn't assume the ones we wrote
+  # are the only ones there are.
+  readmd <- grp$get_metadata()
+  expect_equivalent(readmd[["baz"]], "qux")
+  expect_equivalent(readmd[["foo"]], "bar")
 })


### PR DESCRIPTION
Validation:

```
library(tiledbsc)
data("pbmc_small", package = "SeuratObject")
soco <- SOMACollection$new(uri = "soco-test")
soco$from_seurat(object = pbmc_small)
```

Using [desc-soma](https://github.com/single-cell-data/TileDB-SingleCell/blob/main/apis/python/tools/desc-soma) from [tiledbsc-py](https://github.com/single-cell-data/TileDB-SingleCell/blob/main/apis/python):

```
$ desc-soma soco-test/soma_RNA
Array: soco-test/soma_RNA/X/data
ArraySchema(
...
...
METADATA:
[soma_RNA]
- soma_encoding_version: b'0'
- soma_object_type: b'SOMA'
  [X]
  - key: b'rna_'
  - soma_encoding_version: b'0'
  - soma_object_type: b'AssayMatrixGroup'
    [data]
    [counts]
    [scale.data]
  [varm]
  - soma_encoding_version: b'0'
  - soma_object_type: b'AnnotationMatrixGroup'
    [dimreduction_pca]
    - dimreduction_key: b'PC_'
    - dimreduction_technique: b'pca'
    - soma_encoding_version: b'0'
    - soma_object_type: b'AnnotationMatrix'
  [obsm]
  - soma_encoding_version: b'0'
  - soma_object_type: b'AnnotationMatrixGroup'
    [dimreduction_pca]
    - dimreduction_key: b'PC_'
    - dimreduction_technique: b'pca'
    - soma_encoding_version: b'0'
    - soma_object_type: b'AnnotationMatrix'
    [dimreduction_tsne]
    - dimreduction_key: b'tSNE_'
    - dimreduction_technique: b'tsne'
    - soma_encoding_version: b'0'
    - soma_object_type: b'AnnotationMatrix'
  [varp]
  - soma_encoding_version: b'0'
  - soma_object_type: b'AnnotationPairwiseMatrixGroup'
  [obs]
  - soma_encoding_version: b'0'
  - soma_object_type: b'AnnotationDataframe'
  [uns]
  - soma_encoding_version: b'0'
  - soma_object_type: b'TileDBGroup'
  [obsp]
  - soma_encoding_version: b'0'
  - soma_object_type: b'AnnotationPairwiseMatrixGroup'
    [graph_snn]
    - assay_used: b'RNA'
    - graph_technique: b'snn'
    - soma_encoding_version: b'0'
    - soma_object_type: b'AnnotationPairwiseMatrix'
  [var]
  - soma_encoding_version: b'0'
  - soma_object_type: b'AnnotationDataframe'
```

Note: I'm a bit puzzled by the `b` in `b'TileDBGroup'` ... however, this reads back fine in R:

```
> library(tiledb)
> arr <- tiledb_array('./soma_RNA/obs')
> arr <- tiledb_array_open(arr, 'READ')
> tiledb_get_metadata(arr, 'soma_object_type')
[1] "AnnotationDataframe"
```