### PR TITLE
Update tiledb-r to 0.14

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     R6,
     methods,
     Matrix,
-    tiledb (>= 0.13.0),
+    tiledb (>= 0.14.0),
     SeuratObject,
     jsonlite,
     glue,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.2.9007
+Version: 0.1.2.9008
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,7 @@ See the new *Filtering* vignette for details.
 - `soma_object_type` and `soma_encoding_version` metadata are written to groups/arrays at write time
 - Minimum required version of tiledb-r is now 0.14.0, which also updates TileDB to version 2.10
 - `AnnotationDataframe$from_dataframe()` no longer coerces `logical` columns to `integer`s, as TileDB 2.10 provides support for `BOOL` data types
+- Messages about updating existing arrays are only printed in verbose mode
 
 # tiledbsc 0.1.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,8 @@ See the new *Filtering* vignette for details.
 - Added missing `config`/`ctx` fields to `AnnotationGroup`
 - `AnnotationDataframe` gains `ids()` to retrieve all values from the array's dimension
 - `soma_object_type` and `soma_encoding_version` metadata are written to groups/arrays at write time
+- Minimum required version of tiledb-r is now 0.14.0, which also updates TileDB to version 2.10
+- `AnnotationDataframe$from_dataframe()` no longer coerces `logical` columns to `integer`s, as TileDB 2.10 provides support for `BOOL` data types
 
 # tiledbsc 0.1.2
 

--- a/R/AnnotationDataframe.R
+++ b/R/AnnotationDataframe.R
@@ -37,11 +37,6 @@ AnnotationDataframe <- R6::R6Class(
         "'index_col' must be a scalar character" = is_scalar_character(index_col)
       )
 
-      # logicals are not supported by tiledb::fromDataFrame so we convert
-      # them to integers
-      logical_cols <- vapply_lgl(x, is.logical)
-      x[logical_cols] <- as.data.frame(lapply(x[logical_cols], as.integer))
-
       # convert rownames to a column
       x[[index_col]] <- rownames(x)
       if (!self$exists()) {

--- a/R/AnnotationDataframe.R
+++ b/R/AnnotationDataframe.R
@@ -48,7 +48,11 @@ AnnotationDataframe <- R6::R6Class(
         )
         private$create_empty_array(x, index_col, capacity = capacity)
       } else {
-        message(sprintf("Updating existing %s at '%s'", self$class(), self$uri))
+        if (self$verbose) {
+          message(
+            sprintf("Updating existing %s at '%s'", self$class(), self$uri)
+          )
+        }
       }
       private$ingest_data(x)
     },

--- a/R/AnnotationMatrix.R
+++ b/R/AnnotationMatrix.R
@@ -33,7 +33,11 @@ AnnotationMatrix <- R6::R6Class(
       if (!self$exists()) {
         private$create_empty_array(x, index_col)
       } else {
-        message(sprintf("Updating existing %s at '%s'", self$class(), self$uri))
+        if (self$verbose) {
+          message(
+            sprintf("Updating existing %s at '%s'", self$class(), self$uri)
+          )
+        }
       }
       private$ingest_data(x)
     },

--- a/R/AnnotationPairwiseMatrix.R
+++ b/R/AnnotationPairwiseMatrix.R
@@ -37,7 +37,11 @@ AnnotationPairwiseMatrix <- R6::R6Class(
       if (!self$exists()) {
         private$create_empty_array(x, index_cols)
       } else {
-        message(sprintf("Updating existing %s at '%s'", self$class(), self$uri))
+        if (self$verbose) {
+          message(
+            sprintf("Updating existing %s at '%s'", self$class(), self$uri)
+          )
+        }
       }
       private$ingest_data(x)
     },

--- a/R/AssayMatrix.R
+++ b/R/AssayMatrix.R
@@ -57,7 +57,11 @@ AssayMatrix <- R6::R6Class(
       if (!self$exists()) {
         private$create_empty_array(x, index_cols)
       } else {
-        message(sprintf("Updating existing %s at '%s'", self$class(), self$uri))
+        if (self$verbose) {
+          message(
+            sprintf("Updating existing %s at '%s'", self$class(), self$uri)
+          )
+        }
       }
       private$ingest_data(x, index_cols)
     },

--- a/R/CommandsArray.R
+++ b/R/CommandsArray.R
@@ -37,7 +37,11 @@ CommandsArray <- R6::R6Class(
       if (!self$exists()) {
         private$create_empty_array(command_dataframe, "index")
       } else {
-        message(sprintf("Updating existing %s at '%s'", self$class(), self$uri))
+        if (self$verbose) {
+          message(
+            sprintf("Updating existing %s at '%s'", self$class(), self$uri)
+          )
+        }
       }
       private$ingest_data(command_dataframe)
     },

--- a/tests/testthat/test_AnnotationDataFrame.R
+++ b/tests/testthat/test_AnnotationDataFrame.R
@@ -22,8 +22,17 @@ test_that("annotation dataframe can be stored and retrieved", {
   expect_true(annotdf$exists())
   expect_s4_class(annotdf$tiledb_array(), "tiledb_array")
   expect_is(annotdf$object, "tiledb_array")
+
+  # data types
+  expect_equal(tiledb::datatype(annotdf$attributes()[["character"]]), "ASCII")
+  expect_equal(tiledb::datatype(annotdf$attributes()[["double"]]), "FLOAT64")
+  expect_equal(tiledb::datatype(annotdf$attributes()[["integer"]]), "INT32")
+  expect_equal(tiledb::datatype(annotdf$attributes()[["logical"]]), "BOOL")
+
+  # helpers
   expect_setequal(annotdf$ids(), rownames(df))
 
+  # retrieved dataframe
   df2 <- annotdf$to_dataframe()
   expect_setequal(rownames(df2), rownames(df))
   expect_setequal(colnames(df2), colnames(df))

--- a/tests/testthat/test_AnnotationDataFrame.R
+++ b/tests/testthat/test_AnnotationDataFrame.R
@@ -25,12 +25,9 @@ test_that("annotation dataframe can be stored and retrieved", {
   expect_setequal(annotdf$ids(), rownames(df))
 
   df2 <- annotdf$to_dataframe()
-  expect_equal(sort(rownames(df2)), sort(rownames(df)))
-  expect_equal(sort(colnames(df2)), sort(colnames(df)))
-
-  rlabs <- rownames(df)
-  clabs <- colnames(df)
-  expect_identical(df2[rlabs, clabs], df[rlabs, clabs])
+  expect_setequal(rownames(df2), rownames(df))
+  expect_setequal(colnames(df2), colnames(df))
+  expect_identical(df2, df)
 })
 
 test_that("an empty dataframe can be stored and retrieved", {
@@ -43,5 +40,5 @@ test_that("an empty dataframe can be stored and retrieved", {
 
   df2 <- annotdf$to_dataframe()
   expect_length(df2, 0)
-  expect_equal(sort(rownames(df2)), sort(rownames(df)))
+  expect_setequal(rownames(df2), rownames(df))
 })

--- a/tests/testthat/test_AnnotationDataFrame.R
+++ b/tests/testthat/test_AnnotationDataFrame.R
@@ -1,27 +1,36 @@
 test_that("annotation dataframe can be stored and retrieved", {
   uri <- withr::local_tempdir("annot-df")
 
+  df <- data.frame(
+    character = c("A", "B", "C"),
+    double = c(1.0, 2.0, 3.0),
+    integer = c(1L, 2L, 3L),
+    logical = c(TRUE, FALSE, TRUE)
+  )
+
   annotdf <- AnnotationDataframe$new(uri)
   expect_true(inherits(annotdf, "AnnotationDataframe"))
   expect_error(
-    annotdf$from_dataframe(data.frame(mtcars, row.names = NULL), "obs_id"),
+    annotdf$from_dataframe(df, index_col = "index"),
     "'x' must have character row names"
   )
 
-  annotdf$from_dataframe(mtcars, index_col = "index")
+  rownames(df) <- c("a", "b", "c")
+  annotdf$from_dataframe(df, index_col = "index")
+
   expect_true(dir.exists(annotdf$uri))
   expect_true(annotdf$exists())
   expect_s4_class(annotdf$tiledb_array(), "tiledb_array")
   expect_is(annotdf$object, "tiledb_array")
-  expect_setequal(annotdf$ids(), rownames(mtcars))
+  expect_setequal(annotdf$ids(), rownames(df))
 
-  mtcars2 <- annotdf$to_dataframe()
-  expect_equal(sort(rownames(mtcars2)), sort(rownames(mtcars)))
-  expect_equal(sort(colnames(mtcars2)), sort(colnames(mtcars)))
+  df2 <- annotdf$to_dataframe()
+  expect_equal(sort(rownames(df2)), sort(rownames(df)))
+  expect_equal(sort(colnames(df2)), sort(colnames(df)))
 
-  rlabs <- rownames(mtcars)
-  clabs <- colnames(mtcars)
-  expect_identical(mtcars2[rlabs, clabs], mtcars[rlabs, clabs])
+  rlabs <- rownames(df)
+  clabs <- colnames(df)
+  expect_identical(df2[rlabs, clabs], df[rlabs, clabs])
 })
 
 test_that("an empty dataframe can be stored and retrieved", {


### PR DESCRIPTION
This bumps the minimum required version of tiledb-r to 0.14, which is already available on CRAN. The full changelog for this release is available [here](https://github.com/TileDB-Inc/TileDB-R/releases/tag/0.14.0).

## Changes

- Minimum required version of tiledb-r is now 0.14.0, which also updates TileDB to version 2.10
- `AnnotationDataframe$from_dataframe()` no longer coerces `logical` columns to `integer`s, as TileDB 2.10 provides support for `BOOL` data types
- Messages about updating existing arrays are only printed in verbose mode 
- `AnnotationDataframe` tests were simplified
