### PR TITLE
Disable duplicates for AnnotationArrays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.2.9008
+Version: 0.1.2.9009
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,7 @@ See the new *Filtering* vignette for details.
 - Minimum required version of tiledb-r is now 0.14.0, which also updates TileDB to version 2.10
 - `AnnotationDataframe$from_dataframe()` no longer coerces `logical` columns to `integer`s, as TileDB 2.10 provides support for `BOOL` data types
 - Messages about updating existing arrays are only printed in verbose mode
+- Disable duplicates for `AnnotationArray`s so updates will overwrite existing cells
 
 # tiledbsc 0.1.2
 

--- a/R/AnnotationArray.R
+++ b/R/AnnotationArray.R
@@ -45,6 +45,8 @@ AnnotationArray <- R6::R6Class(
         cell_order = cell_order,
         tile_order = tile_order,
         capacity = capacity,
+        sparse = TRUE,
+        allows_dups = FALSE,
         mode = "schema_only"
       )
       private$write_object_type_metadata()

--- a/R/AnnotationArray.R
+++ b/R/AnnotationArray.R
@@ -1,5 +1,47 @@
 #' Base class for Annotation Arrays
 #'
+#' @description
+#' This is a base class for Annotation arrays that provides common methods for
+#' creating empty arrays and ingesting data.
+#'
+#' @section Duplicates:
+#' Duplicates are always disabled in the schemas created for `AnnotationArray`
+#' objects to guarantee each array cell is associated with a unique value. This
+#' also means that updates to an array cell will overwrite the previous value
+#' (although previous values are still available via time-travel). For example,
+#' consider the following `AnnotationDataframe` (a child of `AnnotationArray`)
+#' with a single cell:
+#'
+#' ```{r}
+#' uri <- file.path(tempdir(), "annotdf")
+#' df <- data.frame(value = 1, row.names = "a")
+#' annotdf <- AnnotationDataframe$new(uri, verbose = FALSE)
+#' annotdf$from_dataframe(df, "id")
+#' ```
+#'
+#' If we update the cell to `value = 2` the previous value `1` will be
+#' overwritten.
+#'
+#' ```{r}
+#' df$value <- 2
+#' annotdf$from_dataframe(df, "id")
+#' annotdf$object[]
+#' ```
+#'
+#' If duplicates were allowed the result would be:
+#'
+#' ```r
+#' $id
+#' [1] "a" "a"
+#'
+#' $value
+#' [1] 1 2
+#'
+#' attr(,"query_status")
+#' [1] "COMPLETE"
+#' ```
+#'
+#'
 #' @importFrom R6 R6Class
 #' @export
 AnnotationArray <- R6::R6Class(

--- a/R/AnnotationArray.R
+++ b/R/AnnotationArray.R
@@ -31,14 +31,14 @@
 #' If duplicates were allowed the result would be:
 #'
 #' ```r
-#' $id
-#' [1] "a" "a"
-#'
-#' $value
-#' [1] 1 2
-#'
-#' attr(,"query_status")
-#' [1] "COMPLETE"
+#' ## $id
+#' ## [1] "a" "a"
+#' ##
+#' ## $value
+#' ## [1] 1 2
+#' ##
+#' ## attr(,"query_status")
+#' ## [1] "COMPLETE"
 #' ```
 #'
 #'

--- a/R/AnnotationArray.R
+++ b/R/AnnotationArray.R
@@ -27,7 +27,7 @@ AnnotationArray <- R6::R6Class(
     # @param capacity Capacity of sparse fragments (default: 10000)
     create_empty_array = function(
       x,
-      index_cols,
+      index_cols = NULL,
       cell_order = "ROW_MAJOR",
       tile_order = "ROW_MAJOR",
       capacity = 10000) {

--- a/R/AnnotationDataframe.R
+++ b/R/AnnotationDataframe.R
@@ -19,10 +19,7 @@ AnnotationDataframe <- R6::R6Class(
 
       # Reset query layout to avoid (sc18770)
       tiledb::query_layout(arr) <- character()
-
-      # TODO: Workaround bug using tiledb::attrs(arr) <- NA_character_
-      # https://github.com/TileDB-Inc/TileDB-R/pull/425
-      arr@attrs <- NA_character_
+      tiledb::attrs(arr) <- NA_character_
       arr[][[1]]
     },
 

--- a/man/AnnotationArray.Rd
+++ b/man/AnnotationArray.Rd
@@ -4,10 +4,55 @@
 \alias{AnnotationArray}
 \title{Base class for Annotation Arrays}
 \description{
-Base class for Annotation Arrays
-
-Base class for Annotation Arrays
+This is a base class for Annotation arrays that provides common methods for
+creating empty arrays and ingesting data.
 }
+\section{Duplicates}{
+
+Duplicates are always disabled in the schemas created for \code{AnnotationArray}
+objects to guarantee each array cell is associated with a unique value. This
+also means that updates to an array cell will overwrite the previous value
+(although previous values are still available via time-travel). For example,
+consider the following \code{AnnotationDataframe} (a child of \code{AnnotationArray})
+with a single cell:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{uri <- file.path(tempdir(), "annotdf")
+df <- data.frame(value = 1, row.names = "a")
+annotdf <- AnnotationDataframe$new(uri, verbose = FALSE)
+annotdf$from_dataframe(df, "id")
+}\if{html}{\out{</div>}}
+
+If we update the cell to \code{value = 2} the previous value \code{1} will be
+overwritten.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{df$value <- 2
+annotdf$from_dataframe(df, "id")
+annotdf$object[]
+}\if{html}{\out{</div>}}
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## $id
+## [1] "a"
+## 
+## $value
+## [1] 2
+## 
+## attr(,"query_status")
+## [1] "COMPLETE"
+}\if{html}{\out{</div>}}
+
+If duplicates were allowed the result would be:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{$id
+[1] "a" "a"
+
+$value
+[1] 1 2
+
+attr(,"query_status")
+[1] "COMPLETE"
+}\if{html}{\out{</div>}}
+}
+
 \section{Super classes}{
 \code{\link[tiledbsc:TileDBObject]{tiledbsc::TileDBObject}} -> \code{\link[tiledbsc:TileDBArray]{tiledbsc::TileDBArray}} -> \code{AnnotationArray}
 }

--- a/tests/testthat/test_AnnotationDataFrame.R
+++ b/tests/testthat/test_AnnotationDataFrame.R
@@ -51,3 +51,16 @@ test_that("an empty dataframe can be stored and retrieved", {
   expect_length(df2, 0)
   expect_setequal(rownames(df2), rownames(df))
 })
+
+test_that("updates overwrite existing cells", {
+  uri <- withr::local_tempdir("annot-df-updates")
+  df <- data.frame(row.names = "a", value = 1)
+
+  annotdf <- AnnotationDataframe$new(uri)
+  annotdf$from_dataframe(df, index_col = "index")
+  expect_identical(annotdf$to_dataframe(), df)
+
+  df2 <- data.frame(row.names = "a", value = 2)
+  annotdf$from_dataframe(df2, index_col = "index")
+  expect_identical(annotdf$to_dataframe(), df2)
+})


### PR DESCRIPTION
The duplicates option is now disabled on TileDB schemas created via `AnnotationArray`-based objects. The reasoning for this is documented in the [`AnnotationArray` class](https://github.com/TileDB-Inc/tiledbsc/blob/977297e68e721e0b329c57737c44097a0fe68178/R/AnnotationArray.R#L7-L42), which I'll copy here:

Duplicates are always disabled in the schemas created for `AnnotationArray`
objects to guarantee each array cell is associated with a unique value. This
also means that updates to an array cell will overwrite the previous value
(although previous values are still available via time-travel). For example,
consider the following `AnnotationDataframe` (a child of `AnnotationArray`)
with a single cell:

```r
uri <- file.path(tempdir(), "annotdf")
df <- data.frame(value = 1, row.names = "a")
annotdf <- AnnotationDataframe$new(uri, verbose = FALSE)
annotdf$from_dataframe(df, "id")
```

If we update the cell to `value = 2` the previous value `1` will be
overwritten.

```r
df$value <- 2
annotdf$from_dataframe(df, "id")
annotdf$object[]

## $id
## [1] "a"
## 
## $value
## [1] 2
## 
## attr(,"query_status")
## [1] "COMPLETE"
```

If duplicates _were_ allowed the result would be:

```r
## $id
## [1] "a" "a"
## 
## $value
## [1] 1 2
##
## attr(,"query_status")
## [1] "COMPLETE"
```
