### PR TITLE
Release 0.1.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,12 @@
 Package: tiledbsc
 Type: Package
-Title: TileDB Single Cell API
-Description: Store and retrieve single cell data using TileDB and the on-disk
-  format proposed in the Unified Single Cell Data Model and API. Users can
-  import from and export to in-memory formats used by popular toolchains like
-  Seurat and Bioconductor SingleCellExperiment.
+Title: TileDB Single Cell SOMA API
+Description: Interface for working with 'TileDB'-based Stack of Matrices,
+    Annotated ('SOMA'): an open data model for representing annotated matrices,
+    like those commonly used for single cell data analysis. Users can import
+    from and export to in-memory formats used by popular toolchains like
+    'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
+    package.
 Version: 0.1.3
 Authors@R: c(
     person(given = "Aaron",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Store and retrieve single cell data using TileDB and the on-disk
   format proposed in the Unified Single Cell Data Model and API. Users can
   import from and export to in-memory formats used by popular toolchains like
   Seurat and Bioconductor SingleCellExperiment.
-Version: 0.1.2.9009
+Version: 0.1.3
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Authors@R: c(
            role = c("cph", "fnd"))
     )
 URL: https://github.com/TileDB-Inc/tiledbsc,
-    https://github.com/single-cell-data/matrix-api
+    https://github.com/single-cell-data/SOMA
 BugReports: https://github.com/TileDB-Inc/tiledbsc/issues
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@ To ease the transition, the `SCDataset` and `SCGroup` classes are still availabl
 
 ## New location for miscellaneous/unstructured data
 
-Previously, the `SCDataset` and `SCGroup` classes included a TileDB group called `misc` that was intended for miscellaneous/unstructured data. To better align with the SOMA matrix-api specification this group has been renamed to `uns`. Practically, this means new `SOMA`s and `SOMACollection`s will create TileDB groups named `uns`, rather than `misc`. And these groups can be accessed with the `SOMA` and `SOMACollection` classes using `SOMA$uns`.
+Previously, the `SCDataset` and `SCGroup` classes included a TileDB group called `misc` that was intended for miscellaneous/unstructured data. To better align with the SOMA specification this group has been renamed to `uns`. Practically, this means new `SOMA`s and `SOMACollection`s will create TileDB groups named `uns`, rather than `misc`. And these groups can be accessed with the `SOMA` and `SOMACollection` classes using `SOMA$uns`.
 
 For backwards compatibility:
 - if a `misc` group exists within a `SOMACollection` or `SOMA` on disk, it will be accessible via the `uns` field of the parent class

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# tiledbsc (development version)
+# tiledbsc 0.1.3
 
 ## Migration to SOMA-based names
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Migration to SOMA-based names
 
-This release changes the names of the 2 top-level classes in the tiledbsc package to follow new nomenclature adopted by the [single-cell data model specification](https://github.com/single-cell-data/matrix-api/blob/main/specification.md), which was implemented [here](https://github.com/single-cell-data/matrix-api/pull/28). You can read more about the rationale for this change [here](https://github.com/single-cell-data/matrix-api/issues/11#issuecomment-1109975498).
+This release changes the names of the 2 top-level classes in the tiledbsc package to follow new nomenclature adopted by the [single-cell data model specification](https://github.com/single-cell-data/soma), which was implemented [here](https://github.com/single-cell-data/soma/pull/28). You can read more about the rationale for this change [here](https://github.com/single-cell-data/soma/issues/11#issuecomment-1109975498).
 
 Additionally, the `misc` slot has been renamed to `uns`. See below for details.
 
@@ -67,7 +67,7 @@ Improve handling of Seurat objects with empty cell identities (#58).
 
 tiledbsc now uses the enhanced Group API's introduced in TileDB v2.8 and TileDB-R 0.12.0.
 
-*Note: The next version of tiledbsc will migrate to the new SOMA-based naming scheme described [here](https://github.com/single-cell-data/matrix-api/issues/27).*
+*Note: The next version of tiledbsc will migrate to the new SOMA-based naming scheme described [here](https://github.com/single-cell-data/soma/issues/27).*
 ## On-disk changes
 
 Group-level metadata is now natively supported by TileDB so `TileDBGroup`-based classes no longer create nested `__tiledb_group_metadata` arrays for the purpose of storing group-level metadata.

--- a/R/tiledbsc-package.R
+++ b/R/tiledbsc-package.R
@@ -1,6 +1,6 @@
 #' @details The API is designed around R6-based classes corresponding to the
 #' components described in the [data model
-#' specification](https://github.com/single-cell-data/soma/blob/main/specification.md).
+#' specification](https://github.com/single-cell-data/soma).
 #'
 #' @keywords internal
 #' @import tiledb

--- a/R/tiledbsc-package.R
+++ b/R/tiledbsc-package.R
@@ -1,6 +1,6 @@
 #' @details The API is designed around R6-based classes corresponding to the
 #' components described in the [data model
-#' specification](https://github.com/single-cell-data/matrix-api/blob/main/specification.md).
+#' specification](https://github.com/single-cell-data/soma/blob/main/specification.md).
 #'
 #' @keywords internal
 #' @import tiledb

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![R-CMD-check](https://github.com/TileDB-Inc/tiledbsc/workflows/R-CMD-check/badge.svg)](https://github.com/TileDB-Inc/tiledbsc/actions)
 <!-- badges: end -->
 
-This is a POC R implementation of the proposed [Unified Single-cell Data Model](https://github.com/single-cell-data/SOMA).
+An R implementation of the [Stack of Matrices, Annotated][soma-spec] (SOMA) API based on [TileDB](https://tiledb.com). SOMA is an open data model for representing annotated matrices, like those commonly used for single-cell data analysis. With tiledbsc, users can import from and export to in-memory formats used by popular toolchains like [Seurat][], [Bioconductor][bioc], and even [AnnData][] using the companion [Python package][tiledbsc-py].
 
 ## Installation
 
@@ -14,3 +14,13 @@ You can install the development version of *tiledbsc* from [GitHub](https://gith
 # install.packages("remotes")
 remotes::install_github("tiledb-inc/tiledbsc")
 ```
+
+<!-- link -->
+[tiledb]: https://tiledb.com
+[soma-spec]: https://github.com/single-cell-data/SOMA
+[seurat]: https://satijalab.org/seurat/
+[bioc]: https://www.bioconductor.org/packages/release/bioc/html/Seurat.html
+[bioc-se]: https://www.bioconductor.org/packages/SummarizedExperiment/
+[bioc-sce]: https://www.bioconductor.org/packages/SingleCellExperiment/
+[anndata]: https://anndata.readthedocs.io
+[tiledbsc-py]: https://github.com/single-cell-data/TileDB-SingleCell

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![R-CMD-check](https://github.com/TileDB-Inc/tiledbsc/workflows/R-CMD-check/badge.svg)](https://github.com/TileDB-Inc/tiledbsc/actions)
 <!-- badges: end -->
 
-This is a POC R implementation of the proposed [Unified Single-cell Data Model](https://github.com/single-cell-data/matrix-api).
+This is a POC R implementation of the proposed [Unified Single-cell Data Model](https://github.com/single-cell-data/SOMA).
 
 ## Installation
 

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -109,7 +109,7 @@ fs::dir_tree(soma$uri, recurse = FALSE)
 
 Any of the underlying TileDB arrays can be accessed directly from a `SOMACollection` object by navigating its internal classes.
 
-As an example, let's access the cell-level metadata. Recall from the [`matrix-api spec`][matrix-api-spec] that cell-level metadata is stored in the `obs` array of an `SOMA`. Therefore, we must first access a specific `SOMA` within the `SOMACollection`'s `somas` slot. Let's generate a list of the available `SOMA`s:
+As an example, let's access the cell-level metadata. Recall from the [*SOMA* spec][soma-spec] that cell-level metadata is stored in the `obs` array of an `SOMA`. Therefore, we must first access a specific `SOMA` within the `SOMACollection`'s `somas` slot. Let's generate a list of the available `SOMA`s:
 
 ```{r}
 names(soco$somas)
@@ -188,4 +188,4 @@ tiledb::tiledb_vfs_remove_dir(data_dir)
 
 <!-- links -->
 [tiledb-r]: https://tiledb-inc.github.io/TileDB-R/
-[matrix-api-spec]: https://github.com/single-cell-data/soma/blob/main/specification.md
+[soma-spec]: https://github.com/single-cell-data/soma

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -188,4 +188,4 @@ tiledb::tiledb_vfs_remove_dir(data_dir)
 
 <!-- links -->
 [tiledb-r]: https://tiledb-inc.github.io/TileDB-R/
-[matrix-api-spec]: https://github.com/single-cell-data/matrix-api/blob/main/specification.md
+[matrix-api-spec]: https://github.com/single-cell-data/soma/blob/main/specification.md


### PR DESCRIPTION
This updates the package to 0.1.3. See [NEWS.md](https://github.com/TileDB-Inc/tiledbsc/blob/aaronwolen/sc-19040/release-0-1-3/NEWS.md) for a full description of changes since the last release.

## Other changes

- Updated package title, description, and README to mention SOMA
- URLs pointing to the old *matrix-api* repo have been updated
- URLs pointing to the spec have been updated to point to the SOMA repo
