### PR TITLE
Add batch mode to assay matrix readers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,8 @@ Imports:
     glue,
     utils,
     fs,
-    urltools
+    urltools,
+    vctrs
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.0
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     from and export to in-memory formats used by popular toolchains like
     'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
     package.
-Version: 0.1.3.9000
+Version: 0.1.3.9001
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,24 @@
 # tiledbsc (development version)
 
+## Features
+
+* Added `batch_mode` option to methods that read `X` layers (i.e., `AssayMatrix` objects) into memory. When enabled, batch mode leverages the family of `Batched` classes added to tiledb-r in version [0.14.0](https://github.com/TileDB-Inc/TileDB-R/releases/tag/0.14.0) to detect partial query results and resubmit until all results are retrieved. This feature is currently disabled by default and only applies to `X` layers (which are typically the largest arrays). You can enable batch mode from the following methods:
+  - `SOMACollection$to_seurat()`
+  - `SOMA$to_seurat_assay()`
+  - `SOMA$to_summarized_experiment()`
+  - `SOMA$to_single_cell_experiment()`
+  - `AssayMatrix$to_dataframe()`
+  - `AssayMatrix$to_matrix()`
+
 * Members can now be removed from `TileDBGroup`s with `remove_member()`
+
+## Fixes
+
+* Matrix conversion message from `AssayMatrix` now respects the `verbose` option
+
+## Build and Test Systems
+
+- Added `with_allocation_size_preference()` helper to temporarily set the allocation size preference for testing.
 
 # tiledbsc 0.1.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 ## Fixes
 
 * Matrix conversion message from `AssayMatrix` now respects the `verbose` option
+* Upon initialization `SOMA` now  looks for a `raw` group and warns the user it will be ignored. Currently tiledbsc-py creates a `raw` group when converting anndata objects where `.raw` is populated. However, Seurat/BioC objects do not have an obvious place to store this data, so ignoring it improves compatibility.
 
 ## Build and Test Systems
 

--- a/R/AssayMatrix.R
+++ b/R/AssayMatrix.R
@@ -30,8 +30,8 @@ AssayMatrix <- R6::R6Class(
     from_matrix = function(x, index_cols, value_col = "value") {
       if (inherits(x, "dgCMatrix")) {
         if (self$verbose) message("Converting to dgTMatrix")
-          x <- as(x, "dgTMatrix")
-        }
+        x <- as(x, "dgTMatrix")
+      }
       stopifnot(
         "'x' must be a dgTMatrix" = inherits(x, "dgTMatrix"),
         "Must provide 'index_cols' to name the index columns" = !missing(index_cols),

--- a/R/AssayMatrix.R
+++ b/R/AssayMatrix.R
@@ -69,7 +69,8 @@ AssayMatrix <- R6::R6Class(
     #' @description Retrieve the assay data from TileDB
     #' @param attrs Specify one or more attributes to retrieve. If `NULL`,
     #' all attributes are retrieved.
-    #' @param batched logical, if `TRUE`, the data is retrieved in batches.
+    #' @param batched logical, if `TRUE`, batched query mode is enabled,
+    #' which provides the ability to detect partial query results and resubmit #' until completion.
     #' @return A [`Matrix::dgTMatrix-class`].
     to_dataframe = function(attrs = NULL, batched = FALSE) {
       if (self$verbose) {
@@ -101,6 +102,8 @@ AssayMatrix <- R6::R6Class(
     #' @description Retrieve assay data from TileDB as a 2D sparse matrix.
     #' @param attr The name of the attribute layer to retrieve. If `NULL`, the
     #' first layer is returned.
+    #' @param batched logical, if `TRUE`, batched query mode is enabled,
+    #' which provides the ability to detect partial query results and resubmit #' until completion.
     #' @return A [`Matrix::dgTMatrix-class`].
     to_matrix = function(attr = NULL, batched = FALSE) {
       if (is.null(attr)) {

--- a/R/AssayMatrix.R
+++ b/R/AssayMatrix.R
@@ -6,7 +6,9 @@
 #' that share the same dimensions and non-empty coordinates.
 #'
 #' Used for the `X` field of [`SOMA`].
-
+#' @param batch_mode logical, if `TRUE`, batch query mode is enabled, which
+#' provides the ability to detect partial query results and resubmit until
+#' all results are retrieved.
 #' @importFrom Matrix sparseMatrix
 #' @export
 
@@ -69,8 +71,6 @@ AssayMatrix <- R6::R6Class(
     #' @description Retrieve the assay data from TileDB
     #' @param attrs Specify one or more attributes to retrieve. If `NULL`,
     #' all attributes are retrieved.
-    #' @param batch_mode logical, if `TRUE`, batch query mode is enabled,
-    #' which provides the ability to detect partial query results and resubmit #' until completion.
     #' @return A [`Matrix::dgTMatrix-class`].
     to_dataframe = function(attrs = NULL, batch_mode = FALSE) {
       if (self$verbose) {
@@ -102,8 +102,6 @@ AssayMatrix <- R6::R6Class(
     #' @description Retrieve assay data from TileDB as a 2D sparse matrix.
     #' @param attr The name of the attribute layer to retrieve. If `NULL`, the
     #' first layer is returned.
-    #' @param batch_mode logical, if `TRUE`, batch query mode is enabled,
-    #' which provides the ability to detect partial query results and resubmit #' until completion.
     #' @return A [`Matrix::dgTMatrix-class`].
     to_matrix = function(attr = NULL, batch_mode = FALSE) {
       if (is.null(attr)) {

--- a/R/AssayMatrix.R
+++ b/R/AssayMatrix.R
@@ -27,7 +27,7 @@ AssayMatrix <- R6::R6Class(
     #' contain the matrix values.
     from_matrix = function(x, index_cols, value_col = "value") {
       if (inherits(x, "dgCMatrix")) {
-          message("Converting to dgTMatrix")
+        if (self$verbose) message("Converting to dgTMatrix")
           x <- as(x, "dgTMatrix")
         }
       stopifnot(

--- a/R/AssayMatrix.R
+++ b/R/AssayMatrix.R
@@ -93,7 +93,7 @@ AssayMatrix <- R6::R6Class(
       stopifnot(is_scalar_character(attr))
 
       assay_data <- self$to_dataframe(attrs = attr)
-      assay_dims <- vapply(assay_data[1:2], n_unique, FUN.VALUE = integer(1L))
+      assay_dims <- vapply_int(assay_data[1:2], n_unique)
       row_labels <- unique(assay_data[[1]])
       col_labels <- unique(assay_data[[2]])
 

--- a/R/AssayMatrix.R
+++ b/R/AssayMatrix.R
@@ -69,10 +69,10 @@ AssayMatrix <- R6::R6Class(
     #' @description Retrieve the assay data from TileDB
     #' @param attrs Specify one or more attributes to retrieve. If `NULL`,
     #' all attributes are retrieved.
-    #' @param batched logical, if `TRUE`, batched query mode is enabled,
+    #' @param batch_mode logical, if `TRUE`, batch query mode is enabled,
     #' which provides the ability to detect partial query results and resubmit #' until completion.
     #' @return A [`Matrix::dgTMatrix-class`].
-    to_dataframe = function(attrs = NULL, batched = FALSE) {
+    to_dataframe = function(attrs = NULL, batch_mode = FALSE) {
       if (self$verbose) {
         message(
           sprintf("Reading %s into memory from '%s'", self$class(), self$uri)
@@ -82,7 +82,7 @@ AssayMatrix <- R6::R6Class(
       tiledb::attrs(arr) <- attrs %||% character()
       tiledb::return_as(arr) <- "data.frame"
 
-      if (batched) {
+      if (batch_mode) {
         if (self$verbose) message("...reading in batches")
         batcher <- tiledb:::createBatched(arr)
         results <- list()
@@ -102,16 +102,16 @@ AssayMatrix <- R6::R6Class(
     #' @description Retrieve assay data from TileDB as a 2D sparse matrix.
     #' @param attr The name of the attribute layer to retrieve. If `NULL`, the
     #' first layer is returned.
-    #' @param batched logical, if `TRUE`, batched query mode is enabled,
+    #' @param batch_mode logical, if `TRUE`, batch query mode is enabled,
     #' which provides the ability to detect partial query results and resubmit #' until completion.
     #' @return A [`Matrix::dgTMatrix-class`].
-    to_matrix = function(attr = NULL, batched = FALSE) {
+    to_matrix = function(attr = NULL, batch_mode = FALSE) {
       if (is.null(attr)) {
         attr <- self$attrnames()[1]
       }
       stopifnot(is_scalar_character(attr))
 
-      assay_data <- self$to_dataframe(attrs = attr, batched = batched)
+      assay_data <- self$to_dataframe(attrs = attr, batch_mode = batch_mode)
       assay_dims <- vapply_int(assay_data[1:2], n_unique)
       row_labels <- unique(assay_data[[1]])
       col_labels <- unique(assay_data[[2]])

--- a/R/SOMA.R
+++ b/R/SOMA.R
@@ -750,6 +750,19 @@ SOMA <- R6::R6Class(
     # metadata).
     instantiate_members = function() {
       members <- self$list_members()
+
+      # Currently tiledbsc-py creates a `raw` group when converting anndata
+      # objects where `.raw` is populated. However, Seurat/BioC objects do not
+      # have an obvious place to store this data, so we ignore it for now.
+      if ("raw" %in% members$NAME) {
+        warning(
+          "Ignoring unsupported 'raw' group",
+          call. = FALSE,
+          immediate. = TRUE
+        )
+        members <- members[members$NAME != "raw", ]
+      }
+
       named_uris <- setNames(members$URI, members$NAME)
 
       # TODO: Remove when SCDataset/SCGroup/misc is defunct

--- a/R/SOMA.R
+++ b/R/SOMA.R
@@ -8,6 +8,9 @@
 #' - `obs` ([`AnnotationDataframe`]): 1D labeled array with column labels for
 #'   `X`
 #' - `var` ([`AnnotationDataframe`]): 1D labeled array with row labels for `X`
+#' @param batch_mode logical, if `TRUE`, batch query mode is enabled for
+#' retrieving `X` layers. See [`AssayMatrix$to_dataframe()`][`AssayMatrix`] for
+#' more information.
 #' @importFrom SeuratObject AddMetaData Loadings Embeddings VariableFeatures
 #' @importFrom SeuratObject GetAssayData CreateAssayObject SetAssayData
 #' @export
@@ -413,9 +416,6 @@ SOMA <- R6::R6Class(
     #' detected.
     #' @param check_matrix Check counts matrix for NA, NaN, Inf, and non-integer
     #' values
-    #' @param batch_mode logical, if `TRUE`, batch query mode is enabled for
-    #' retrieving `X` layers. See
-    #' [`AssayMatrix$to_dataframe()`][`AssayMatrix`] for more information.
     #' @param ... Arguments passed to [`SeuratObject::as.sparse`]
     to_seurat_assay = function(
       layers = c("counts", "data", "scale.data"),
@@ -653,9 +653,6 @@ SOMA <- R6::R6Class(
     #' or more of the available `X` [`AssayMatrix`] layers. If `layers` is
     #' *named* (e.g., `c(logdata = "counts")`) the assays will adopt the names
     #' of the layers vector.
-    #' @param batch_mode logical, if `TRUE`, batch query mode is enabled for
-    #' retrieving `X` layers. See
-    #' [`AssayMatrix$to_dataframe()`][`AssayMatrix`] for more information.
     to_summarized_experiment = function(
       layers = c("counts", "data", "scale.data"),
       batch_mode = FALSE
@@ -688,9 +685,6 @@ SOMA <- R6::R6Class(
     #' or more of the available `X` [`AssayMatrix`] layers. If `layers` is
     #' *named* (e.g., `c(logdata = "counts")`) the assays will adopt the names
     #' of the layers vector.
-    #' @param batch_mode logical, if `TRUE`, batch query mode is enabled for
-    #' retrieving `X` layers. See
-    #' [`AssayMatrix$to_dataframe()`][`AssayMatrix`] for more information.
     to_single_cell_experiment = function(
       layers = c("counts", "data"),
       batch_mode = FALSE

--- a/R/SOMACollection.R
+++ b/R/SOMACollection.R
@@ -198,10 +198,16 @@ SOMACollection <- R6::R6Class(
 
     #' @description Convert to a [SeuratObject::Seurat] object.
     #' @param project [`SeuratObject::Project`] name for the `Seurat` object
-    to_seurat = function(project = "SeuratProject") {
+    #' @param batch_mode logical, if `TRUE`, batch query mode is enabled for
+    #' retrieving `X` layers. See
+    #' [`AssayMatrix$to_dataframe()`][`AssayMatrix`] for more information.
+    to_seurat = function(project = "SeuratProject", batch_mode = FALSE) {
       stopifnot(is_scalar_character(project))
 
-      assays <- lapply(self$somas, function(x) x$to_seurat_assay())
+      assays <- lapply(
+        X = self$somas,
+        FUN = function(x) x$to_seurat_assay(batch_mode = batch_mode)
+      )
       nassays <- length(assays)
 
       # cell-level obs metadata is stored in each soma, so for now we

--- a/R/utils-dgtmatrix.R
+++ b/R/utils-dgtmatrix.R
@@ -95,6 +95,7 @@ dataframe_to_dgtmatrix <- function(x, index_cols = c("i", "j")) {
 #' @importFrom Matrix nnzero
 are_layerable <- function(x, y) {
   stopifnot(is_matrix(x) && is_matrix(y))
+  if (identical(x, y)) return(TRUE)
   dimnames_match <- identical(dimnames(x), dimnames(y))
   nonemptycells_match <- Matrix::nnzero(x) == Matrix::nnzero(y)
   dimnames_match && nonemptycells_match

--- a/man/AssayMatrix.Rd
+++ b/man/AssayMatrix.Rd
@@ -112,8 +112,9 @@ Retrieve the assay data from TileDB
 \item{\code{attrs}}{Specify one or more attributes to retrieve. If \code{NULL},
 all attributes are retrieved.}
 
-\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled,
-which provides the ability to detect partial query results and resubmit #' until completion.}
+\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled, which
+provides the ability to detect partial query results and resubmit until
+all results are retrieved.}
 }
 \if{html}{\out{</div>}}
 }
@@ -136,8 +137,9 @@ Retrieve assay data from TileDB as a 2D sparse matrix.
 \item{\code{attr}}{The name of the attribute layer to retrieve. If \code{NULL}, the
 first layer is returned.}
 
-\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled,
-which provides the ability to detect partial query results and resubmit #' until completion.}
+\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled, which
+provides the ability to detect partial query results and resubmit until
+all results are retrieved.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/AssayMatrix.Rd
+++ b/man/AssayMatrix.Rd
@@ -103,7 +103,7 @@ other columns are ingested as attributes.}
 \subsection{Method \code{to_dataframe()}}{
 Retrieve the assay data from TileDB
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{AssayMatrix$to_dataframe(attrs = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{AssayMatrix$to_dataframe(attrs = NULL, batch_mode = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -111,6 +111,9 @@ Retrieve the assay data from TileDB
 \describe{
 \item{\code{attrs}}{Specify one or more attributes to retrieve. If \code{NULL},
 all attributes are retrieved.}
+
+\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled,
+which provides the ability to detect partial query results and resubmit #' until completion.}
 }
 \if{html}{\out{</div>}}
 }
@@ -124,7 +127,7 @@ A \code{\link[Matrix:dgTMatrix-class]{Matrix::dgTMatrix}}.
 \subsection{Method \code{to_matrix()}}{
 Retrieve assay data from TileDB as a 2D sparse matrix.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{AssayMatrix$to_matrix(attr = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{AssayMatrix$to_matrix(attr = NULL, batch_mode = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -132,6 +135,9 @@ Retrieve assay data from TileDB as a 2D sparse matrix.
 \describe{
 \item{\code{attr}}{The name of the attribute layer to retrieve. If \code{NULL}, the
 first layer is returned.}
+
+\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled,
+which provides the ability to detect partial query results and resubmit #' until completion.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/SOMA.Rd
+++ b/man/SOMA.Rd
@@ -276,8 +276,8 @@ detected.}
 values}
 
 \item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
-retrieving \code{X} layers. See
-\code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for more information.}
+retrieving \code{X} layers. See \code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for
+more information.}
 
 \item{\code{...}}{Arguments passed to \code{\link[SeuratObject:as.sparse]{SeuratObject::as.sparse}}}
 }
@@ -395,8 +395,8 @@ or more of the available \code{X} \code{\link{AssayMatrix}} layers. If \code{lay
 of the layers vector.}
 
 \item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
-retrieving \code{X} layers. See
-\code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for more information.}
+retrieving \code{X} layers. See \code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for
+more information.}
 }
 \if{html}{\out{</div>}}
 }
@@ -432,8 +432,8 @@ or more of the available \code{X} \code{\link{AssayMatrix}} layers. If \code{lay
 of the layers vector.}
 
 \item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
-retrieving \code{X} layers. See
-\code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for more information.}
+retrieving \code{X} layers. See \code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for
+more information.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/SOMA.Rd
+++ b/man/SOMA.Rd
@@ -254,6 +254,7 @@ Convert to a \code{\link[SeuratObject:Assay-class]{SeuratObject::Assay}} object.
   min_cells = 0,
   min_features = 0,
   check_matrix = FALSE,
+  batch_mode = FALSE,
   ...
 )}\if{html}{\out{</div>}}
 }
@@ -273,6 +274,10 @@ detected.}
 
 \item{\code{check_matrix}}{Check counts matrix for NA, NaN, Inf, and non-integer
 values}
+
+\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
+retrieving \code{X} layers. See
+\code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for more information.}
 
 \item{\code{...}}{Arguments passed to \code{\link[SeuratObject:as.sparse]{SeuratObject::as.sparse}}}
 }
@@ -375,7 +380,10 @@ Convert to a \link[SeuratObject:Seurat-class]{SeuratObject::Seurat} object.
 Convert to a \link[SummarizedExperiment:RangedSummarizedExperiment-class]{SummarizedExperiment::SummarizedExperiment}
 object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMA$to_summarized_experiment(layers = c("counts", "data", "scale.data"))}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMA$to_summarized_experiment(
+  layers = c("counts", "data", "scale.data"),
+  batch_mode = FALSE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -385,6 +393,10 @@ object.
 or more of the available \code{X} \code{\link{AssayMatrix}} layers. If \code{layers} is
 \emph{named} (e.g., \code{c(logdata = "counts")}) the assays will adopt the names
 of the layers vector.}
+
+\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
+retrieving \code{X} layers. See
+\code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for more information.}
 }
 \if{html}{\out{</div>}}
 }
@@ -405,7 +417,10 @@ with a subset of features is included.
 Convert to a Bioconductor
 \link[SingleCellExperiment:SingleCellExperiment]{SingleCellExperiment::SingleCellExperiment} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMA$to_single_cell_experiment(layers = c("counts", "data"))}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMA$to_single_cell_experiment(
+  layers = c("counts", "data"),
+  batch_mode = FALSE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -415,6 +430,10 @@ Convert to a Bioconductor
 or more of the available \code{X} \code{\link{AssayMatrix}} layers. If \code{layers} is
 \emph{named} (e.g., \code{c(logdata = "counts")}) the assays will adopt the names
 of the layers vector.}
+
+\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
+retrieving \code{X} layers. See
+\code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for more information.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/SOMACollection.Rd
+++ b/man/SOMACollection.Rd
@@ -175,13 +175,17 @@ dimensionality reduction method (e.g., \code{"pca"}).
 \subsection{Method \code{to_seurat()}}{
 Convert to a \link[SeuratObject:Seurat-class]{SeuratObject::Seurat} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMACollection$to_seurat(project = "SeuratProject")}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMACollection$to_seurat(project = "SeuratProject", batch_mode = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{project}}{\code{\link[SeuratObject:Project]{SeuratObject::Project}} name for the \code{Seurat} object}
+
+\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
+retrieving \code{X} layers. See
+\code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for more information.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -5,3 +5,14 @@ fac2char <- function(x) {
   x[factcols] <- lapply(x[factcols], as.character)
   return(x)
 }
+
+
+# Temporarily set the allocation size preference
+with_allocation_size_preference <- function(value, .local_envir = parent.frame()) {
+  orig_value <- tiledb::get_allocation_size_preference()
+  withr::defer(
+    tiledb::set_allocation_size_preference(orig_value),
+    envir = .local_envir
+  )
+  tiledb::set_allocation_size_preference(value)
+}

--- a/tests/testthat/test-AssayMatrixGroup.R
+++ b/tests/testthat/test-AssayMatrixGroup.R
@@ -1,0 +1,13 @@
+test_that("New matrices can be added", {
+  uri <- withr::local_tempdir("assay-matrix-group")
+  mat <- SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
+
+  assaymats <- AssayMatrixGroup$new(uri = uri, dimension_name = c("obs_id", "var_id"))
+  expect_length(assaymats$members, 0)
+
+  assaymats$add_assay_matrix(
+    data = SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts"),
+    name = "counts"
+  )
+  expect_true(inherits(assaymats$members[["counts"]], "AssayMatrix"))
+})

--- a/tests/testthat/test_AssayMatrix.R
+++ b/tests/testthat/test_AssayMatrix.R
@@ -16,6 +16,7 @@ test_that("AssayMatrix object can be created from a dgCMatrix", {
   expect_setequal(unique(df2$j), colnames(mat))
 
   mat2 <- assaymat$to_matrix()
+  expect_s4_class(mat2, "dgTMatrix")
   expect_equal(sort(rownames(mat2)), sort(rownames(mat)))
   expect_equal(sort(colnames(mat2)), sort(colnames(mat)))
 

--- a/tests/testthat/test_AssayMatrix.R
+++ b/tests/testthat/test_AssayMatrix.R
@@ -9,6 +9,12 @@ test_that("AssayMatrix object can be created from a dgCMatrix", {
   expect_true(dir.exists(uri))
   expect_s4_class(assaymat$tiledb_array(), "tiledb_array")
 
+  df2 <- assaymat$to_dataframe()
+  expect_s3_class(df2, "data.frame")
+  expect_equal(attr(df2, "query_status"), "COMPLETE")
+  expect_setequal(unique(df2$i), rownames(mat))
+  expect_setequal(unique(df2$j), colnames(mat))
+
   mat2 <- assaymat$to_matrix()
   expect_equal(sort(rownames(mat2)), sort(rownames(mat)))
   expect_equal(sort(colnames(mat2)), sort(colnames(mat)))

--- a/tests/testthat/test_AssayMatrix.R
+++ b/tests/testthat/test_AssayMatrix.R
@@ -46,8 +46,8 @@ test_that("Incomplete queries can be completed via batching", {
   assaymat <- AssayMatrix$new(uri = uri, verbose = TRUE)
   assaymat$from_matrix(smat, index_cols = c("i", "j"), value_col = "counts")
 
-  df1 <- assaymat$to_dataframe(batched = FALSE)
-  df2 <- assaymat$to_dataframe(batched = TRUE)
+  df1 <- assaymat$to_dataframe(batch_mode = FALSE)
+  df2 <- assaymat$to_dataframe(batch_mode = TRUE)
   expect_equal(dim(df1), dim(df2))
 })
 

--- a/tests/testthat/test_AssayMatrix.R
+++ b/tests/testthat/test_AssayMatrix.R
@@ -29,6 +29,7 @@ test_that("AssayMatrix object can be created from a dgCMatrix", {
 
 test_that("Incomplete queries can be completed via batching", {
   uri <- withr::local_tempdir("assay-matrix-batched")
+  with_allocation_size_preference(5e5)
 
   nr <- 1e3
   nc <- 1e2
@@ -45,7 +46,6 @@ test_that("Incomplete queries can be completed via batching", {
   assaymat <- AssayMatrix$new(uri = uri, verbose = TRUE)
   assaymat$from_matrix(smat, index_cols = c("i", "j"), value_col = "counts")
 
-  set_allocation_size_preference(5e5)
   df1 <- assaymat$to_dataframe(batched = FALSE)
   df2 <- assaymat$to_dataframe(batched = TRUE)
   expect_equal(dim(df1), dim(df2))

--- a/tests/testthat/test_AssayMatrix.R
+++ b/tests/testthat/test_AssayMatrix.R
@@ -26,18 +26,3 @@ test_that("AssayMatrix object can be created from a dgCMatrix", {
   clabs <- colnames(mat2)
   expect_equal(mat1[rlabs, clabs], mat2[rlabs, clabs])
 })
-
-
-test_that("matrices can be added to an AssayMatrixGroup", {
-  uri <- withr::local_tempdir("assay-matrix-group")
-  mat <- SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts")
-
-  assaymats <- AssayMatrixGroup$new(uri = uri, dimension_name = c("obs_id", "var_id"))
-  expect_length(assaymats$members, 0)
-
-  assaymats$add_assay_matrix(
-    data = SeuratObject::GetAssayData(pbmc_small[["RNA"]], "counts"),
-    name = "counts"
-  )
-  expect_true(inherits(assaymats$members[["counts"]], "AssayMatrix"))
-})

--- a/tests/testthat/test_AssayMatrix.R
+++ b/tests/testthat/test_AssayMatrix.R
@@ -17,8 +17,8 @@ test_that("AssayMatrix object can be created from a dgCMatrix", {
 
   mat2 <- assaymat$to_matrix()
   expect_s4_class(mat2, "dgTMatrix")
-  expect_equal(sort(rownames(mat2)), sort(rownames(mat)))
-  expect_equal(sort(colnames(mat2)), sort(colnames(mat)))
+  expect_setequal(rownames(mat2), rownames(mat))
+  expect_setequal(colnames(mat2), colnames(mat))
 
   # coerce to dgTMatrix so we can compare directly
   mat1 <- as(mat, "dgTMatrix")

--- a/tests/testthat/test_SOMA_Seurat.R
+++ b/tests/testthat/test_SOMA_Seurat.R
@@ -102,6 +102,18 @@ test_that("Seurat Assay can be recreated from an existing SOMA", {
     SeuratObject::GetAssayData(assay2, "data")[var_ids, obs_ids],
     SeuratObject::GetAssayData(assay1, "data")[var_ids, obs_ids]
   )
+
+  # Seurat assay conversion with batch mode on
+  with_allocation_size_preference(1e4)
+  expect_message(
+    assay3 <- soma$to_seurat_assay(batch_mode = TRUE, layers = "counts"),
+    "...reading in batches"
+  )
+
+  expect_identical(
+    SeuratObject::GetAssayData(assay3, "counts")[var_ids, obs_ids],
+    SeuratObject::GetAssayData(assay1, "counts")[var_ids, obs_ids]
+  )
 })
 
 test_that("Individual layers can be retrieved from an existing SOMA", {


### PR DESCRIPTION
## Features

Adds `batch_mode` option to methods that read `X` layers (i.e., `AssayMatrix` objects) into memory. When enabled, batch mode leverages the family of `Batched` classes added to tiledb-r in version [0.14.0](https://github.com/TileDB-Inc/TileDB-R/releases/tag/0.14.0) to detect partial query results and resubmit until all results are retrieved. This feature is currently disabled by default and only applies to `X` layers (which are typically the largest arrays). You can enable batch mode from the following methods:
  - `SOMACollection$to_seurat()`
  - `SOMA$to_seurat_assay()`
  - `SOMA$to_summarized_experiment()`
  - `SOMA$to_single_cell_experiment()`
  - `AssayMatrix$to_dataframe()`
  - `AssayMatrix$to_matrix()`

## Fixes

* Matrix conversion message from `AssayMatrix` now respects the `verbose` option
* Upon initialization `SOMA` now  looks for a `raw` group and warns the user it will be ignored. Currently tiledbsc-py creates a `raw` group when converting anndata objects where `.raw` is populated. However, Seurat/BioC objects do not have an obvious place to store this data, so ignoring it improves compatibility.

## Build and Test Systems

- Added `with_allocation_size_preference()` helper to temporarily set the allocation size preference for testing
