### PR TITLE
Makefile for rendering vignettes as Jupyter notebooks

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^LICENSE\.md$
 ^\.github$
 ^data-raw$
+^Makefile$

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+rscript := Rscript --no-save --no-restore
+
+rmds     := $(wildcard vignettes/*.Rmd)
+mds      := $(rmds:%.Rmd=%.md)
+ipynbs   := $(rmds:%.Rmd=%.ipynb)
+
+jupyter: $(ipynbs)
+
+%.ipynb: %.md
+	@echo "Converting $< to $@"
+	pandoc --from markdown --to ipynb --output $@ $<
+
+%.md: %.Rmd
+	@echo "Converting $< to $@"
+	@$(rscript) -e "rmarkdown::render(input = '$<', output_file = '$(@F)', output_dir = '$(@D)', output_format = rmarkdown::md_document(variant = 'commonmark', preserve_yaml = TRUE))"
+	@sed -i '' 's/``` r/``` code/g' $@
+
+clean:
+	rm -f vignettes/*.{md,ipynb}


### PR DESCRIPTION
Adds a single rule Makefile for rendering package Rmd vignettes to markdown and then converting to ipynb via Pandoc. Goal here is to make sharing/distributing vignettes via TileDB Cloud easier.