### PR TITLE
Don't use default assay name for Seurat objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     from and export to in-memory formats used by popular toolchains like
     'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
     package.
-Version: 0.1.3.9005
+Version: 0.1.3.9006
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@
 * Upon initialization `SOMA` now  looks for a `raw` group and warns the user it will be ignored. Currently tiledbsc-py creates a `raw` group when converting anndata objects where `.raw` is populated. However, Seurat/BioC objects do not have an obvious place to store this data, so ignoring it improves compatibility.
 * Fixed a non-user-facing issue with the internal `dgtmatrix_to_dataframe()` function used to convert unordered `dgTMatrix` objects to COO data frames (#73).
 * Pretty printing of classes that inherit from `TileDBObject` has been improved so that the class name is displayed first (#79).
+* Don't use default assay name when recreating a `Seurat` object (#80, thanks @dan11mcguire)
 
 ## Build and Test Systems
 

--- a/R/SOMACollection.R
+++ b/R/SOMACollection.R
@@ -215,7 +215,7 @@ SOMACollection <- R6::R6Class(
       obs_df <- self$somas[[1]]$obs$to_dataframe()
 
       # retain cell identities before restoring cell-level metadata
-  idents <- obs_df$active_ident
+      idents <- obs_df$active_ident
       if (!is.null(idents)) {
         idents <- stats::setNames(idents, rownames(obs_df))
         obs_df$active_ident <- NULL
@@ -224,7 +224,8 @@ SOMACollection <- R6::R6Class(
       object <- SeuratObject::CreateSeuratObject(
         counts = assays[[1]],
         project = project,
-        meta.data = obs_df
+        meta.data = obs_df,
+        assay = names(assays)[1]
       )
 
       if (!is.null(idents)) {


### PR DESCRIPTION
This implements @dan11mcguire's fix for #82. Previously we were implicitly using Seurat's default name for the first assay created by `to_seurat()`. Now we always explicitly supply an assay name from the corresponding SOMA.