### PR TITLE
Expand batched reader support to AnnotationMatrix arrays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     from and export to in-memory formats used by popular toolchains like
     'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
     package.
-Version: 0.1.4
+Version: 0.1.4.9000
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# tiledbsc (development version)
+
+## Features
+
+- The `AnnotationMatrix`'s `to_matrix()` method now supports batched reads via the `batch_mode` argument. This functionality can also be leveraged from `SOMA`'s  `get_seurat_dimreductions_list()` and `get_seurat_dimreduction()` methods. (#86)
+
 # tiledbsc 0.1.4
 
 ## Features

--- a/R/AnnotationMatrix.R
+++ b/R/AnnotationMatrix.R
@@ -3,6 +3,9 @@
 #' Base class for matrix-like data with rows aligned to the observations or
 #' features of a [`SOMA`].
 #'
+#' @param batch_mode logical, if `TRUE`, batch query mode is enabled, which
+#' provides the ability to detect partial query results and resubmit until
+#' all results are retrieved.
 #' @export
 
 AnnotationMatrix <- R6::R6Class(
@@ -42,15 +45,17 @@ AnnotationMatrix <- R6::R6Class(
     },
 
     #' @description Retrieve the annotation data from TileDB
+    #' @param attrs A character vector of the attribute names to retrieve. By
+    #' default, all attributes are retrieved.
     #' @return A [`matrix`]
-    to_matrix = function() {
-      if (self$verbose) {
-        message(
-          sprintf("Reading %s into memory from '%s'", self$class(), self$uri)
-        )
-      }
+    to_matrix = function(attrs = NULL, batch_mode = FALSE) {
 
-      df <- self$tiledb_array(return_as = "data.frame")[]
+      df <- private$read_data(
+        attrs = attrs,
+        batch_mode = batch_mode,
+        return_as = "data.frame"
+      )
+
       index_col <- self$dimnames()
       attr_cols <- setdiff(colnames(df), index_col)
 

--- a/R/AssayMatrix.R
+++ b/R/AssayMatrix.R
@@ -70,30 +70,11 @@ AssayMatrix <- R6::R6Class(
     #' @return A [`Matrix::dgTMatrix-class`].
     #' @importFrom vctrs vec_rbind
     to_dataframe = function(attrs = NULL, batch_mode = FALSE) {
-      if (self$verbose) {
-        message(
-          sprintf("Reading %s into memory from '%s'", self$class(), self$uri)
-        )
-      }
-      arr <- self$object
-      tiledb::attrs(arr) <- attrs %||% character()
-      tiledb::return_as(arr) <- "data.frame"
-
-      if (batch_mode) {
-        if (self$verbose) message("...reading in batches")
-        batcher <- tiledb:::createBatched(arr)
-        results <- list()
-        i <- 1
-        while(isFALSE(tiledb::completedBatched(batcher))) {
-          if (self$verbose) message(sprintf("...retrieving batch %d", i))
-          results[[i]] <- tiledb::fetchBatched(arr, batcher)
-          i <- i + 1
-        }
-        results <- vctrs::vec_rbind(!!!results)
-      } else {
-        results <- arr[]
-      }
-      results
+      private$read_data(
+        attrs = attrs,
+        batch_mode = batch_mode,
+        return_as = "data.frame"
+      )
     },
 
     #' @description Retrieve assay data from TileDB as a 2D sparse matrix.
@@ -106,7 +87,12 @@ AssayMatrix <- R6::R6Class(
       }
       stopifnot(is_scalar_character(attr))
 
-      assay_data <- self$to_dataframe(attrs = attr, batch_mode = batch_mode)
+      assay_data <- private$read_data(
+        attrs = attr,
+        batch_mode = batch_mode,
+        return_as = "data.frame"
+      )
+
       assay_dims <- vapply_int(assay_data[1:2], n_unique)
       row_labels <- unique(assay_data[[1]])
       col_labels <- unique(assay_data[[2]])

--- a/R/SOMA.R
+++ b/R/SOMA.R
@@ -562,7 +562,7 @@ SOMA <- R6::R6Class(
     #' @param technique Name of the dimensionality reduction technique. Used to
     #' identify which `obsm`/`varm` array will be retrieved. If `NULL`, we
     #' default to the first `obsm/dimreduction_` array.
-    get_seurat_dimreduction = function(technique = NULL) {
+    get_seurat_dimreduction = function(technique = NULL, batch_mode = FALSE) {
 
       # Identify all obsm/varm dimreduction_ arrays
       prefix <- "dimreduction_"
@@ -599,7 +599,9 @@ SOMA <- R6::R6Class(
       }
 
       # TODO: validate we're only returning 1 array per dimension
-      mats <- lapply(arrays, function(x) x[[1]]$to_matrix())
+      mats <- lapply(arrays,
+        function(x) x[[1]]$to_matrix(batch_mode = batch_mode)
+      )
 
       # TODO: validate all keys match? For now just take the first one
       key <- unlist(arrays)[[1]]$get_metadata(key = "dimreduction_key")
@@ -613,13 +615,13 @@ SOMA <- R6::R6Class(
     },
 
     #' @description Retrieve a list of all [`SeuratObject::DimReduc`] objects.
-    get_seurat_dimreductions_list = function() {
-      arrays <-self$get_annotation_matrix_arrays(prefix = "dimreduction_")
+    get_seurat_dimreductions_list = function(batch_mode = FALSE) {
+      arrays <- self$get_annotation_matrix_arrays(prefix = "dimreduction_")
       array_names <- names(unlist(arrays))
       techniques <- unique(sub("(obs|var)m\\.dimreduction_", "", array_names))
       sapply(
         techniques,
-        function(x) self$get_seurat_dimreduction(x),
+        function(x) self$get_seurat_dimreduction(x, batch_mode = batch_mode),
         simplify = FALSE,
         USE.NAMES = TRUE
       )

--- a/R/SOMACollection.R
+++ b/R/SOMACollection.R
@@ -199,7 +199,7 @@ SOMACollection <- R6::R6Class(
     #' @description Convert to a [SeuratObject::Seurat] object.
     #' @param project [`SeuratObject::Project`] name for the `Seurat` object
     #' @param batch_mode logical, if `TRUE`, batch query mode is enabled for
-    #' retrieving `X` layers. See
+    #' retrieving `X`, `obsm`/`varm`, and `obsp`/`varp` layers. See
     #' [`AssayMatrix$to_dataframe()`][`AssayMatrix`] for more information.
     to_seurat = function(project = "SeuratProject", batch_mode = FALSE) {
       stopifnot(is_scalar_character(project))
@@ -243,9 +243,8 @@ SOMACollection <- R6::R6Class(
       # Retrieve list of all techniques used in any soma's obsm/varm
       # dimensionality reduction arrays. The association between assay and
       # dimreduction is maintained by the DimReduc's `assay.used` slot.
-      dimreductions <- lapply(
-        self$somas,
-        function(x) x$get_seurat_dimreductions_list()
+      dimreductions <- lapply(self$somas,
+        function(x) x$get_seurat_dimreductions_list(batch_mode)
       )
       object@reductions <- Reduce(base::c, dimreductions)
 

--- a/man/AnnotationMatrix.Rd
+++ b/man/AnnotationMatrix.Rd
@@ -79,9 +79,21 @@ contain the matrix row names.}
 \subsection{Method \code{to_matrix()}}{
 Retrieve the annotation data from TileDB
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{AnnotationMatrix$to_matrix()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{AnnotationMatrix$to_matrix(attrs = NULL, batch_mode = FALSE)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{attrs}}{A character vector of the attribute names to retrieve. By
+default, all attributes are retrieved.}
+
+\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled, which
+provides the ability to detect partial query results and resubmit until
+all results are retrieved.}
+}
+\if{html}{\out{</div>}}
+}
 \subsection{Returns}{
 A \code{\link{matrix}}
 }

--- a/man/SOMA.Rd
+++ b/man/SOMA.Rd
@@ -333,7 +333,7 @@ results column names (required by Seurat)
 \subsection{Method \code{get_seurat_dimreduction()}}{
 Convert to a \code{\link[SeuratObject:DimReduc-class]{SeuratObject::DimReduc}} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMA$get_seurat_dimreduction(technique = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMA$get_seurat_dimreduction(technique = NULL, batch_mode = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -342,6 +342,10 @@ Convert to a \code{\link[SeuratObject:DimReduc-class]{SeuratObject::DimReduc}} o
 \item{\code{technique}}{Name of the dimensionality reduction technique. Used to
 identify which \code{obsm}/\code{varm} array will be retrieved. If \code{NULL}, we
 default to the first \code{obsm/dimreduction_} array.}
+
+\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
+retrieving \code{X} layers. See \code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for
+more information.}
 }
 \if{html}{\out{</div>}}
 }
@@ -352,9 +356,18 @@ default to the first \code{obsm/dimreduction_} array.}
 \subsection{Method \code{get_seurat_dimreductions_list()}}{
 Retrieve a list of all \code{\link[SeuratObject:DimReduc-class]{SeuratObject::DimReduc}} objects.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMA$get_seurat_dimreductions_list()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMA$get_seurat_dimreductions_list(batch_mode = FALSE)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
+retrieving \code{X} layers. See \code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for
+more information.}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-SOMA-to_seurat_object"></a>}}

--- a/man/SOMACollection.Rd
+++ b/man/SOMACollection.Rd
@@ -184,7 +184,7 @@ Convert to a \link[SeuratObject:Seurat-class]{SeuratObject::Seurat} object.
 \item{\code{project}}{\code{\link[SeuratObject:Project]{SeuratObject::Project}} name for the \code{Seurat} object}
 
 \item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
-retrieving \code{X} layers. See
+retrieving \code{X}, \code{obsm}/\code{varm}, and \code{obsp}/\code{varp} layers. See
 \code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for more information.}
 }
 \if{html}{\out{</div>}}

--- a/tests/testthat/test_AnnotationMatrix.R
+++ b/tests/testthat/test_AnnotationMatrix.R
@@ -23,4 +23,8 @@ test_that("annotation matrix can be stored and retrieved", {
   expect_equal(sort(colnames(mat2)), sort(colnames(mat)))
 
   expect_identical(mat[rlabs, clabs], mat2[rlabs, clabs])
+
+  # test that result is identical with batch mode
+  mat3 <- annotmat$to_matrix(batch_mode = TRUE)
+  expect_identical(mat2, mat3)
 })


### PR DESCRIPTION
This PR expands batched reader support to the `AnnotationMatrix` class. It's off by default but can be enabled with the `batch_mode` argument that was added to the `to_matrix()` method. 