### PR TITLE
Make SOMAs and X layers selectable when converting to a Seurat object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Interface for working with 'TileDB'-based Stack of Matrices,
     from and export to in-memory formats used by popular toolchains like
     'Seurat', 'Bioconductor', and even 'AnnData' using the companion Python
     package.
-Version: 0.1.4.9000
+Version: 0.1.4.9001
 Authors@R: c(
     person(given = "Aaron",
            family = "Wolen",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Features
 
 - The `AnnotationMatrix`'s `to_matrix()` method now supports batched reads via the `batch_mode` argument. This functionality can also be leveraged from `SOMA`'s  `get_seurat_dimreductions_list()` and `get_seurat_dimreduction()` methods. (#86)
+- The `SOMACollection`'s `to_seurat()` method gains a `somas` argument that makes it possible to select a subset of `SOMA`s and `X` layers to be retrieved. (#89)
 
 # tiledbsc 0.1.4
 

--- a/R/SOMACollection.R
+++ b/R/SOMACollection.R
@@ -199,14 +199,48 @@ SOMACollection <- R6::R6Class(
     #' @description Convert to a [SeuratObject::Seurat] object.
     #' @param project [`SeuratObject::Project`] name for the `Seurat` object
     #' @param batch_mode logical, if `TRUE`, batch query mode is enabled for
-    #' retrieving `X`, `obsm`/`varm`, and `obsp`/`varp` layers. See
+    #' retrieving `X` layers. See
     #' [`AssayMatrix$to_dataframe()`][`AssayMatrix`] for more information.
-    to_seurat = function(project = "SeuratProject", batch_mode = FALSE) {
-      stopifnot(is_scalar_character(project))
+    #' @param somas character vector, names of `SOMA`s to include as
+    #' [`SeuratObject::Assay`]s in the `Seurat` object. If `NULL`, all `SOMA`s
+    #' are included. Can also be a named list of character vectors, where each
+    #' element corresponds to a `SOMA` name and the value is a character vector
+    #' of `X` layers from that `SOMA` to include as assays (e.g., `list("RNA" =
+    #' c("counts", "logcounts"))`).
+    to_seurat = function(
+      project = "SeuratProject",
+      somas = NULL,
+      batch_mode = FALSE
+    ) {
+      stopifnot(
+        is_scalar_character(project),
+        "'somas' must be a character vector or named list"
+          = is.null(somas) || is.character(somas) || is.list(somas)
+      )
 
-      assays <- lapply(
-        X = self$somas,
-        FUN = function(x) x$to_seurat_assay(batch_mode = batch_mode)
+      # default list containing all somas and all layers
+      soma_list <- sapply(
+        names(self$somas),
+        FUN = function(x) c("counts", "data", "scale.data"),
+        simplify = FALSE
+      )
+
+      if (is.character(somas)) {
+        stopifnot(assert_subset(somas, names(soma_list)))
+        soma_list <- soma_list[somas]
+      } else if (is.list(somas)) {
+        stopifnot(assert_subset(names(somas), names(soma_list)))
+        soma_list <- somas
+      }
+
+      assays <- mapply(
+        FUN = function(soma, layers, batch_mode) {
+          soma$to_seurat_assay(layers = layers, batch_mode = batch_mode)
+        },
+        soma = self$somas[names(soma_list)],
+        layers = soma_list,
+        MoreArgs = list(batch_mode = batch_mode),
+        SIMPLIFY = FALSE
       )
       nassays <- length(assays)
 
@@ -243,8 +277,9 @@ SOMACollection <- R6::R6Class(
       # Retrieve list of all techniques used in any soma's obsm/varm
       # dimensionality reduction arrays. The association between assay and
       # dimreduction is maintained by the DimReduc's `assay.used` slot.
-      dimreductions <- lapply(self$somas,
-        function(x) x$get_seurat_dimreductions_list(batch_mode)
+      dimreductions <- lapply(
+        self$somas,
+        function(x) x$get_seurat_dimreductions_list()
       )
       object@reductions <- Reduce(base::c, dimreductions)
 
@@ -351,7 +386,7 @@ SCDataset <- R6::R6Class(
       .Deprecated(
         new = "SOMACollection",
         old = "SCDataset",
-        package = "tiledbsc"
+        package = "tiledbsoma"
       )
       super$initialize(uri, verbose, config, ctx)
     },
@@ -363,7 +398,7 @@ SCDataset <- R6::R6Class(
       .Deprecated(
         new = "soma_uris",
         old = "scgroup_uri",
-        package = "tiledbsc"
+        package = "tiledbsoma"
       )
       self$soma_uris
     }
@@ -375,14 +410,14 @@ SCDataset <- R6::R6Class(
       if (!missing(value)) {
         stop("scgroups is read-only, use 'add_member()' to add a new SOMA")
       }
-      .Deprecated(new = "somas", old = "scgroups", package = "tiledbsc")
+      .Deprecated(new = "somas", old = "scgroups", package = "tiledbsoma")
       self$somas
     },
 
     #' @field misc An alias for `uns`.
     misc = function(value) {
       if (!missing(value)) stop("misc is read-only")
-      .Deprecated(new = "uns", old = "misc", package = "tiledbsc")
+      .Deprecated(new = "uns", old = "misc", package = "tiledbsoma")
       self$uns
     }
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -105,7 +105,8 @@ file_path <- function(..., fsep = .Platform$file.sep) {
   file.path(..., fsep = fsep)
 }
 
-#' Assert all values of `x` are a subset of `y`. @param x,y vectors of values
+#' Assert all values of `x` are a subset of `y`.
+#' @param x,y vectors of values
 #' @param type A character vector of length 1 used in the error message
 #' @return `TRUE` if all values of `x` are present in `y`, otherwise an
 #' informative error is thrown with the missing values.

--- a/man/SOMACollection.Rd
+++ b/man/SOMACollection.Rd
@@ -175,7 +175,11 @@ dimensionality reduction method (e.g., \code{"pca"}).
 \subsection{Method \code{to_seurat()}}{
 Convert to a \link[SeuratObject:Seurat-class]{SeuratObject::Seurat} object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SOMACollection$to_seurat(project = "SeuratProject", batch_mode = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SOMACollection$to_seurat(
+  project = "SeuratProject",
+  somas = NULL,
+  batch_mode = FALSE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -183,8 +187,14 @@ Convert to a \link[SeuratObject:Seurat-class]{SeuratObject::Seurat} object.
 \describe{
 \item{\code{project}}{\code{\link[SeuratObject:Project]{SeuratObject::Project}} name for the \code{Seurat} object}
 
+\item{\code{somas}}{character vector, names of \code{SOMA}s to include as
+\code{\link[SeuratObject:Assay-class]{SeuratObject::Assay}}s in the \code{Seurat} object. If \code{NULL}, all \code{SOMA}s
+are included. Can also be a named list of character vectors, where each
+element corresponds to a \code{SOMA} name and the value is a character vector
+of \code{X} layers from that \code{SOMA} to include as assays (e.g., \code{list("RNA" = c("counts", "logcounts"))}).}
+
 \item{\code{batch_mode}}{logical, if \code{TRUE}, batch query mode is enabled for
-retrieving \code{X}, \code{obsm}/\code{varm}, and \code{obsp}/\code{varp} layers. See
+retrieving \code{X} layers. See
 \code{\link[=AssayMatrix]{AssayMatrix$to_dataframe()}} for more information.}
 }
 \if{html}{\out{</div>}}

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -16,3 +16,18 @@ with_allocation_size_preference <- function(value, .local_envir = parent.frame()
   )
   tiledb::set_allocation_size_preference(value)
 }
+
+
+#' Compare data.frames or matrices after sorting dimensions
+#' Useful for comparing objects were numerically or lexicographically sorted
+#' after being reconstituted from TileDB.
+#' @noRd
+expect_equal_after_ordering_dims <- function(object, expected, ...) {
+  stopifnot(
+    is.data.frame(object) || is_matrix(object),
+    is.data.frame(expected) || is_matrix(expected)
+  )
+
+  object <- object[rownames(expected), colnames(expected)]
+  testthat::expect_equal(object, expected, ...)
+}


### PR DESCRIPTION
This adds a `somas` argument to `SOMACollection`'s `to_seurat()` method to  select a subset of `SOMA`s and `X` layers to retrieve.


character vector, names of `SOMA`s to include asThis PR adds a `somas` argument to `SOMACollection`'s `to_seurat()` method that allows you to select a subset of `SOMA`s and, optionally, `X` layers when converting to a `Seurat` object. 

You can pass either a vector of `SOMA` names

```r
soco$to_seurat(somas = c("SOMA1", "SOMA2"))
```

_or_ a named list of character vectors, where each element corresponds to a `SOMA` name and the value is a character vector of `X` layers from that `SOMA` to include in the corresponding Seurat `Assay`:

```r
soco$to_seurat(somas = list(SOMA1 = c("counts", "data"), SOMA2 = "counts"))
```
