### PR TITLE
Update setup-r gha to v2

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 - The `AnnotationMatrix`'s `to_matrix()` method now supports batched reads via the `batch_mode` argument. This functionality can also be leveraged from `SOMA`'s  `get_seurat_dimreductions_list()` and `get_seurat_dimreduction()` methods. (#86)
 - The `SOMACollection`'s `to_seurat()` method gains a `somas` argument that makes it possible to select a subset of `SOMA`s and `X` layers to be retrieved. (#89)
 
+## Changes
+
+- Updated `setup-r` GitHub Action to v2 (#90)
+
 # tiledbsc 0.1.4
 
 ## Features


### PR DESCRIPTION
This updates the `setup-r` github action to v2, now that v1 [is deprecated](https://github.com/single-cell-data/TileDB-SOMA/actions/runs/3525158467/jobs/6059740255#step:5:50).

Note: CI failures are due to a core bug that will be fixed in 2.13.1.