### PR TITLE
Revert back to CI use of tiledb-r from CRAN

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,8 +49,4 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      # need current GH version
-      - name: Update TileDB-R
-        run: Rscript -e 'install.packages("remotes"); remotes::install_github("TileDB-Inc/TileDB-R")'
-          
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
This simple PR reverts the temporary change to install tilebd-r 0.18.0.3 from GitHub (needed when we made it) as 0.19.0 is on CRAN.