### PR TITLE
errors when assay_key is empty

### DIFF
--- a/R/SOMA.R
+++ b/R/SOMA.R
@@ -415,12 +415,15 @@ SOMA <- R6::R6Class(
         spdl::debug("Adding assay key to group-level metadata")
         self$X$add_metadata(list(key = assay_key))
 
-        spdl::info(sprintf(
-        "Finished converting Seurat Assay with key [%s] to %s",
-        assay_key,
-        self$class()
-        ))
+        msg <- sprintf(
+          "Finished converting Seurat Assay with key [%s] to %s",
+          assay_key,
+          self$class()
+        )
+      } else {
+        msg <- sprintf("Finished converting Seurat Assay to %s", self$class())
       }
+      spdl::info(msg)
     },
 
     #' @description Convert to a [`SeuratObject::Assay`] object.

--- a/R/SOMA.R
+++ b/R/SOMA.R
@@ -414,13 +414,13 @@ SOMA <- R6::R6Class(
       if (!is_empty(assay_key)) {
         spdl::debug("Adding assay key to group-level metadata")
         self$X$add_metadata(list(key = assay_key))
-      }
 
-      spdl::info(sprintf(
+        spdl::info(sprintf(
         "Finished converting Seurat Assay with key [%s] to %s",
         assay_key,
         self$class()
-      ))
+        ))
+      }
     },
 
     #' @description Convert to a [`SeuratObject::Assay`] object.


### PR DESCRIPTION
The `assay_key` is not always present and the logging message will error when missing. This PR moves the logging into the already existing is_empty check and only prints when available. 

Another option could be to change the logging statement to not include `assay_key` or set it if empty before printing. Not sure what would be most helpful for these logs. 